### PR TITLE
Add corpus_filepath to Dataset class

### DIFF
--- a/src/datacollective/dataset.py
+++ b/src/datacollective/dataset.py
@@ -90,7 +90,7 @@ class Dataset:
                     continue
 
                 # Store the corpus directory for reference
-                self.corpus_filepath = os.path.dirname(root)
+                self.corpus_filepath = root
                 full_path = os.path.join(root, file)
                 return pd.read_csv(full_path, sep="\t", header="infer")
 


### PR DESCRIPTION
Right now, the `load_dataset` returns the parent / root directory of the dataset. However, it would be useful to also have the full path on where the corpus files are. I am aware that I am adding an extra "hack" to the already "hacky" way of getting the SPS/SCS datasets from the client.