### PR TITLE
341 python api resumable downloads

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
     rev: 25.11.0
     hooks:
       - id: black
-        language_version: python3.11
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.6

--- a/src/datacollective/errors.py
+++ b/src/datacollective/errors.py
@@ -1,4 +1,3 @@
-
 class DownloadError(Exception):
     """Exception raised when a download fails."""
 
@@ -13,6 +12,5 @@ class DownloadError(Exception):
 
     def __str__(self) -> str:
         if self.checksum:
-            return f"""Download failed with {self.downloaded_bytes} bytes written. Run again with resume_download="{self.checksum}" to resume."""
+            return f"""Download failed with {self.downloaded_bytes} bytes written. Run again with resume_download_checksum="{self.checksum}" to resume."""
         return "Download failed. Unfortunately this dataset does not support resuming downloads — please try again."
-        


### PR DESCRIPTION
With this PR, when a download fails, the user is directed to resume the download if they choose. 

They are prompted to call the same function call again, this time with a `resume_download` arg. The arg is set to a checksum of the download, so that we know we're not mixing different downloads. 

This change requires that a dataset has a checksum value returned by the API. This is a new field, not all datasets shall support it (yet). 


Steps to QA:

1 - In a python shell, begin downloading a dataset
```
from datacollective import save_dataset_to_disk
dataset_path = save_dataset_to_disk("cmj324gbx00p4ny078pi26kfz")
```
2 - Interrupt the download (press CTRL+C)
3 - Follow instructions from the error thrown for resuming the download
4 - When the download has concluded, unzip the contents and verify it has been successfully constructed