### PR TITLE
Resolve dataset id and slug to  submission id

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ print(response)
 For predefined licenses, pass `licenseAbbreviation=License.<VALUE>` and leave `licenseUrl` and `license` unset. For custom licenses, pass a custom string to `license` and optionally include `licenseUrl` and `licenseAbbreviation`.
 
 > [!TIP]
-> To upload a new `.tar.gz` version to an already approved dataset, call `upload_dataset_file(file_path=..., submission_id=...)` directly. Find the submission under **Profile → Uploads**, open the approved dataset, and copy the value after `/profile/submissions/` in the URL. Note that this value is the submission ID, which is different from the public dataset ID.
+> To upload a new `.tar.gz` version to an already approved dataset, call `upload_dataset_file(file_path=..., dataset_id_or_slug=...)` directly.
 
 ## For more details, visit [our docs](https://Mozilla-Data-Collective.github.io/datacollective-python/)
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ export MDC_API_KEY=your-api-key-here
 MDC_API_KEY=your-api-key-here
 ```
 
-3. **Get your dataset ID from the last section of the dataset URL at the MDC website**. 
+3. **Get your dataset ID or slug from dataset page at the MDC website**. 
 
 > [!TIP]
-> You can find the `dataset-id` by looking at the URL of the dataset's page on MDC platform. The ID is the unique string of characters located at the very end of the URL, after the `/datasets/` path. For example, for URL `https://datacollective.mozillafoundation.org/datasets/cminc35no007no707hql26lzk` dataset id will be `cminc35no007no707hql26lzk`.
+> You can access datasets either through their unique ID or their slug name. To find them, open the dataset page, click `Connect API`, and look for the `Dataset ID` and `Dataset slug` fields.
 
 4. **Save a dataset locally**:
 ```

--- a/docs/demo_update_file_version.py
+++ b/docs/demo_update_file_version.py
@@ -1,13 +1,13 @@
 from datacollective import upload_dataset_file
 
 # The dataset must already be approved on the platform.
-# Copy the submission ID from:
-# https://datacollective.mozillafoundation.org/profile/submissions/<submission-id>
-approved_submission_id = "XXXXXXXXXXXXX"
+# Copy the dataset ID or slug from:
+# https://datacollective.mozillafoundation.org/datasets/<dataset-id-or-slug>
+dataset_id_or_slug = "XXXXXXXXXXXXX"
 
 upload_state = upload_dataset_file(
     file_path="example_dataset.tar.gz",
-    submission_id=approved_submission_id,
+    dataset_id_or_slug=dataset_id_or_slug,
 )
 
 print(f"Version upload complete! File Upload ID: {upload_state.fileUploadId}")

--- a/docs/demo_update_file_version.py
+++ b/docs/demo_update_file_version.py
@@ -1,8 +1,8 @@
 from datacollective import upload_dataset_file
 
 # The dataset must already be approved on the platform.
-# Copy the dataset ID or slug from:
-# https://datacollective.mozillafoundation.org/datasets/<dataset-id-or-slug>
+# Open the dataset page, click "Connect API", and copy either the
+# "Dataset ID" or the "Dataset slug".
 dataset_id_or_slug = "XXXXXXXXXXXXX"
 
 upload_state = upload_dataset_file(

--- a/docs/index.md
+++ b/docs/index.md
@@ -147,7 +147,7 @@ print(response)
 For predefined licenses, pass `licenseAbbreviation=License.<VALUE>` and leave `licenseUrl` and `license` unset. For a custom license, pass a custom string to `license` and optionally include `licenseUrl` and `licenseAbbreviation`.
 
 > [!TIP]
-> To upload a new `.tar.gz` version to an already approved and published dataset, call `upload_dataset_file(file_path=..., submission_id=...)` directly. Get the submission ID from **Profile → Uploads** by opening the approved dataset and copying the value after `/profile/submissions/` in the URL. This submission ID is different from the dataset ID.
+> To upload a new `.tar.gz` version to an already approved and published dataset, call `upload_dataset_file(file_path=..., dataset_id_or_slug=...)` directly. 
 
 > [!TIP]
 > If a file upload is interrupted, simply rerun the same function above and the upload will resume from where it left off.
@@ -183,7 +183,6 @@ You can retrieve info from the datasheet of a dataset without downloading it:
 from datacollective import get_dataset_details
 
 info = get_dataset_details("your-dataset-id")
-print(info)
 ```
 
 ### Automatic Download Resume

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,7 +73,7 @@ MDC_DOWNLOAD_PATH=~/.mozdata/datasets
 **IMPORTANT NOTE:** Before trying to access any dataset, make sure you have thoroughly **read and agreed** to the specific dataset's conditions & licensing terms.
 
 !!! tip
-    You can find the `dataset-id` by looking at the URL of the dataset's page on MDC platform. The ID is the unique string of characters located at the very end of the URL, after the `/datasets/` path. For example, for URL `https://datacollective.mozillafoundation.org/datasets/cmflnuzw6lrt9e6ui4kwcshvn` dataset id will be `cmflnuzw6lrt9e6ui4kwcshvn`.
+    You can access datasets from the MDC platform using either their unique ID or their slug name. To find them, open the dataset page, click `Connect API`, and look for the `Dataset ID` and `Dataset slug` fields.
 
 ### Download a dataset
 
@@ -82,7 +82,7 @@ Use `download_dataset` to download a dataset to the configured download path:
 ```python
 from datacollective import download_dataset
 
-dataset = download_dataset("your-dataset-id")
+dataset = download_dataset("your-dataset-id-or-slug")
 
 # Depending on the implementation, `dataset` may contain metadata
 # about the downloaded files or a higher-level dataset object.
@@ -163,7 +163,7 @@ analysis:
 ```python
 from datacollective import load_dataset
 
-df = load_dataset("your-dataset-id")
+df = load_dataset("your-dataset-id-or-slug")
 
 # Inspect the loaded DataFrame
 print(df.head())
@@ -182,7 +182,7 @@ You can retrieve info from the datasheet of a dataset without downloading it:
 ```python
 from datacollective import get_dataset_details
 
-info = get_dataset_details("your-dataset-id")
+info = get_dataset_details("your-dataset-id-or-slug")
 ```
 
 ### Automatic Download Resume

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -95,9 +95,9 @@ For predefined licenses, pass `licenseAbbreviation=License.<VALUE>` and leave `l
 Use `upload_dataset_file` when the dataset already exists on the platform and is already in the **Published / Approved** state.
 
 1. Open the dataset page on the platform.
-2. Copy either the dataset ID or the dataset slug from the URL, for example:
-   `https://datacollective.mozillafoundation.org/datasets/<DATASET-ID-OR-SLUG>`
-3. Pass that value to `upload_dataset_file` as `dataset_id_or_slug`.
+2. Click `Connect API`.
+3. Copy either the `Dataset ID` or the `Dataset slug`.
+4. Pass that value to `upload_dataset_file` as `dataset_id_or_slug`.
 
 
 ```python

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -94,23 +94,20 @@ For predefined licenses, pass `licenseAbbreviation=License.<VALUE>` and leave `l
 
 Use `upload_dataset_file` when the dataset already exists on the platform and is already in the **Published / Approved** state.
 
-1. Go to **Profile → Uploads** on the platform.
-2. Click on the dataset submission you want to upload a new version for (must be in an Approved state).
-3. Copy the ID from the URL, for example:
-   `https://datacollective.mozillafoundation.org/profile/submissions/<ID>`
-4. Pass that value to `upload_dataset_file` as `submission_id`.
+1. Open the dataset page on the platform.
+2. Copy either the dataset ID or the dataset slug from the URL, for example:
+   `https://datacollective.mozillafoundation.org/datasets/<DATASET-ID-OR-SLUG>`
+3. Pass that value to `upload_dataset_file` as `dataset_id_or_slug`.
 
-> [!IMPORTANT]
-> The value after `/profile/submissions/` is the **submission ID**, not the dataset ID.
 
 ```python
 from datacollective import upload_dataset_file
 
-approved_submission_id = "XXXXXXXXXXXXXXXXX"  # submission ID, not dataset ID
+dataset_id_or_slug = "my-approved-dataset"
 
 upload_state = upload_dataset_file(
     file_path="/path/to/new-dataset-version.tar.gz",
-    submission_id=approved_submission_id,
+    dataset_id_or_slug=dataset_id_or_slug,
 )
 
 print(f"Version upload complete! File Upload ID: {upload_state.fileUploadId}")
@@ -165,8 +162,6 @@ upload_state = upload_dataset_file(
 print(f"Upload complete! File Upload ID: {upload_state.fileUploadId}")
 ```
 
-> [!TIP]
-> You can also find your submission ID by going to your [Uploads](https://datacollective.mozillafoundation.org/profile/uploads) in your profile, click on the dataset submission of your choice, and the URL will contain the submission ID (e.g., `https://datacollective.mozillafoundation.org/submissions/cmmjpewijXXXXXXXXX`).
 
 ### Step 3: Update Submission Metadata
 

--- a/src/datacollective/submissions.py
+++ b/src/datacollective/submissions.py
@@ -201,7 +201,7 @@ def create_submission_with_upload(
 
     upload_state = upload_dataset_file(
         file_path=file_path,
-        submission_id=submission_id,
+        dataset_id_or_slug=submission_id,
         state_path=state_path,
     )
 

--- a/src/datacollective/upload.py
+++ b/src/datacollective/upload.py
@@ -18,6 +18,7 @@ from datacollective.api_utils import (
     _format_bytes,
     _enable_verbose,
 )
+from datacollective.datasets import get_dataset_details
 from datacollective.models import NonEmptyStrModel, UploadPart
 
 logger = logging.getLogger(__name__)
@@ -156,9 +157,22 @@ def _complete_upload(
     return dict(resp.json())
 
 
+def _resolve_submission_id(dataset_id_or_slug: str) -> str:
+    dataset_details = get_dataset_details(dataset_id_or_slug)
+    resolved_submission_id = dataset_details.get("submission_id")
+    if resolved_submission_id is None or resolved_submission_id == "":
+        raise ValueError(
+            f"Could not resolve dataset '{dataset_id_or_slug}' to a valid submission ID."
+        )
+    logger.debug(
+        f"Resolved dataset {dataset_id_or_slug} to submission {resolved_submission_id} for upload."
+    )
+    return resolved_submission_id
+
+
 def upload_dataset_file(
     file_path: str,
-    submission_id: str,
+    dataset_id_or_slug: str,
     state_path: str | None = None,
     verbose: bool = False,
     show_progress: bool = True,
@@ -167,13 +181,13 @@ def upload_dataset_file(
     Upload a dataset file using multipart uploads with resumable state.
 
     Uploads are limited to 80GB and use the `application/gzip` MIME type.
-    Pass the submission ID of the target dataset submission. This works for
+    Pass the dataset ID or slug of the target dataset submission. This works for
     both draft submissions and for uploading a new `.tar.gz` version to an
     already approved dataset submission.
 
     Args:
         file_path: Path to the dataset archive on disk.
-        submission_id: Dataset submission ID (not the dataset ID).
+        dataset_id_or_slug: Dataset ID or slug.
         state_path: Optional path to persist upload state. Defaults to
             `<filename>.mdc-upload.json` alongside the archive.
         verbose: Whether to enable detailed logging during the upload.
@@ -192,12 +206,15 @@ def upload_dataset_file(
         raise ValueError("`file_path` exceeds the 80GB upload limit")
 
     final_filename = path.name
+    resolved_submission_id = _resolve_submission_id(
+        dataset_id_or_slug=dataset_id_or_slug,
+    )
 
     state_file = Path(state_path) if state_path else _default_state_path(path)
 
     state = _load_or_create_state(
         state_file=state_file,
-        submission_id=submission_id,
+        submission_id=resolved_submission_id,
         final_filename=final_filename,
         file_size=file_size,
     )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -8,6 +8,7 @@ from tests.e2e.helpers import (
     DEFAULT_LIVE_DATASET_ID,
     EXAMPLE_DATASET_ARCHIVE_PATH,
     LIVE_TEST_SKIP_REASON,
+    DEFAULT_LIVE_DATASET_SLUG,
 )
 
 
@@ -43,6 +44,11 @@ def live_download_dir(
 @pytest.fixture(scope="session")
 def dataset_id() -> str:
     return DEFAULT_LIVE_DATASET_ID
+
+
+@pytest.fixture(scope="session")
+def dataset_slug() -> str:
+    return DEFAULT_LIVE_DATASET_SLUG
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -11,6 +11,7 @@ LIVE_TEST_SKIP_REASON = (
     "Set MDC_TEST_API_KEY and MDC_TEST_API_URL to run live API tests."
 )
 DEFAULT_LIVE_DATASET_ID = "cmiq2s3q5000fo207k9g6g7ou"
+DEFAULT_LIVE_DATASET_SLUG = "dataset-for-api-python-sdk-tests-do-not-6529c8c3"
 EXAMPLE_DATASET_ARCHIVE_PATH = (
     Path(__file__).resolve().parents[2] / "docs/example_dataset.tar.gz"
 )

--- a/tests/e2e/test_download_e2e.py
+++ b/tests/e2e/test_download_e2e.py
@@ -18,6 +18,7 @@ from tests.e2e.helpers import skip_if_rate_limited
 def test_get_dataset_details_live_api(
     live_api_env: None,
     dataset_id: str,
+    dataset_slug: str,
 ) -> None:
     """NOTE: This test calls a live MDC API endpoint (dev)."""
 
@@ -30,9 +31,29 @@ def test_get_dataset_details_live_api(
     assert details is not None
     assert isinstance(details, dict)
     assert details.get("id") == dataset_id
+    assert details.get("slug") == dataset_slug
     dataset_name = details.get("name")
     assert isinstance(dataset_name, str)
     assert dataset_name.strip()
+
+
+def test_download_dataset_by_slug(
+    live_api_env: None,
+    dataset_slug: str,
+) -> None:
+    result_path = None
+    try:
+        result_path = download_dataset(
+            dataset_slug,
+            show_progress=False,
+            overwrite_existing=True,
+        )
+    except Exception as exc:
+        skip_if_rate_limited(exc)
+
+    assert result_path is not None
+    assert result_path.exists(), "Downloaded file should exist"
+    assert result_path.stat().st_size > 0, "Downloaded file should not be empty"
 
 
 def test_resume_download(

--- a/tests/test_upload_state.py
+++ b/tests/test_upload_state.py
@@ -79,7 +79,7 @@ def test_resolve_submission_id_for_upload_requires_submission_id_from_dataset_de
     )
 
     with pytest.raises(
-        RuntimeError,
+        ValueError,
         match="Dataset details did not return a `submission_id`",
     ):
         upload_module._resolve_submission_id(
@@ -139,82 +139,3 @@ def test_initiate_upload_posts_submission_id_without_stdout(
 
 class _FakeUploadPartResponse:
     headers = {"ETag": '"etag-1"'}
-
-
-def test_upload_dataset_file_uses_existing_submission_id_for_version_upload(
-    tmp_path: Path, monkeypatch: MonkeyPatch
-) -> None:
-    archive_path = tmp_path / "dataset.tar.gz"
-    archive_path.write_bytes(bytearray(b"versioned-payload"))
-    captured_completion: dict[str, object] = {}
-
-    def fake_load_or_create_state(
-        state_file: Path,
-        submission_id: str,
-        final_filename: str,
-        file_size: int,
-    ) -> UploadState:
-        assert state_file == archive_path.with_name("dataset.tar.gz.mdc-upload.json")
-        assert submission_id == "cmmns07oe001onn07aeidopab"
-        assert final_filename == "dataset.tar.gz"
-        assert file_size == len(b"versioned-payload")
-        return UploadState(
-            submissionId=submission_id,
-            fileUploadId="file-upload-id",
-            uploadId="upload-id",
-            fileSize=file_size,
-            partSize=file_size,
-            filename=final_filename,
-            mimeType="application/gzip",
-            parts=[],
-            checksum=None,
-        )
-
-    def fake_complete_upload(
-        file_upload_id: str,
-        upload_id: str | None,
-        parts: list[upload_module.UploadPart],
-        checksum: str,
-    ) -> dict[str, object]:
-        captured_completion.update(
-            {
-                "fileUploadId": file_upload_id,
-                "uploadId": upload_id,
-                "parts": parts,
-                "checksum": checksum,
-            }
-        )
-        return {"ok": True}
-
-    monkeypatch.setattr(
-        upload_module, "_load_or_create_state", fake_load_or_create_state
-    )
-    monkeypatch.setattr(
-        upload_module,
-        "_get_presigned_part_url",
-        lambda file_upload_id, part_number: upload_module.PresignedPartUrl(
-            partNumber=part_number,
-            url=f"https://upload.example.test/{file_upload_id}/{part_number}",
-        ),
-    )
-    monkeypatch.setattr(
-        upload_module,
-        "_upload_part_with_retry",
-        lambda presigned_url, payload: _FakeUploadPartResponse(),
-    )
-    monkeypatch.setattr(upload_module, "_complete_upload", fake_complete_upload)
-
-    result = upload_dataset_file(
-        file_path=str(archive_path),
-        dataset_id_or_slug="cmmns07oe001onn07aeidopab",
-        show_progress=False,
-    )
-
-    assert result.submissionId == "cmmns07oe001onn07aeidopab"
-    assert result.fileUploadId == "file-upload-id"
-    assert len(result.parts) == 1
-    assert result.parts[0].partNumber == 1
-    assert result.parts[0].etag == "etag-1"
-    assert captured_completion["fileUploadId"] == "file-upload-id"
-    assert captured_completion["uploadId"] == "upload-id"
-    assert not archive_path.with_name("dataset.tar.gz.mdc-upload.json").exists()

--- a/tests/test_upload_state.py
+++ b/tests/test_upload_state.py
@@ -40,7 +40,7 @@ def test_load_upload_state_returns_none_for_invalid_payload(tmp_path: Path) -> N
     state_path = tmp_path / "upload-state.json"
     state_path.write_text(
         """{
-  \"submissionId\": \"submission\",
+  \"submissionId\": \"id\",
   \"fileUploadId\": \"file-upload\",
   \"uploadId\": \"\",
   \"fileSize\": 1024,
@@ -58,7 +58,7 @@ def test_upload_dataset_file_rejects_missing_file(tmp_path: Path) -> None:
     missing_file = tmp_path / "missing.tar.gz"
 
     with pytest.raises(FileNotFoundError, match="File not found"):
-        upload_dataset_file(str(missing_file), submission_id="submission")
+        upload_dataset_file(str(missing_file), dataset_id_or_slug="id")
 
 
 def test_upload_dataset_file_rejects_empty_file(tmp_path: Path) -> None:
@@ -66,7 +66,25 @@ def test_upload_dataset_file_rejects_empty_file(tmp_path: Path) -> None:
     empty_file.write_bytes(bytearray())
 
     with pytest.raises(ValueError, match="non-empty file"):
-        upload_dataset_file(str(empty_file), submission_id="submission")
+        upload_dataset_file(str(empty_file), dataset_id_or_slug="id")
+
+
+def test_resolve_submission_id_for_upload_requires_submission_id_from_dataset_details(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        upload_module,
+        "get_dataset_details",
+        lambda dataset_id: {"id": dataset_id},
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Dataset details did not return a `submission_id`",
+    ):
+        upload_module._resolve_submission_id(
+            dataset_id_or_slug="sample-dataset-slug",
+        )
 
 
 def test_initiate_upload_posts_submission_id_without_stdout(
@@ -188,7 +206,7 @@ def test_upload_dataset_file_uses_existing_submission_id_for_version_upload(
 
     result = upload_dataset_file(
         file_path=str(archive_path),
-        submission_id="cmmns07oe001onn07aeidopab",
+        dataset_id_or_slug="cmmns07oe001onn07aeidopab",
         show_progress=False,
     )
 


### PR DESCRIPTION
Right now, during programmatic uploads, we ask the user to provide the submission ID during resumable uploads. The UX of getting the submission ID is not very clean (get it from the URL). This PR would allow the user to provide the dataset id or slug instead, and the python sdk would resolve it to the submission ID. This would offer a cleaner UX/DX for programmatic uploads.