### PR TITLE
Add file content loading logic

### DIFF
--- a/docs/loaders/asr.md
+++ b/docs/loaders/asr.md
@@ -182,6 +182,36 @@ columns:
 That resolves each row as
 `dataset_root / data/<Split>/<Speaker ID>_khm_<Sentence ID>.wav`.
 
+### File-content dtype
+
+When the index file stores paths to transcription files instead of inline text,
+use `dtype: "file_content"` to read the file contents into the DataFrame:
+
+```yaml
+dataset_id: "speech-data-nupe"
+task: "ASR"
+index_file: "Metadata.csv"
+base_audio_path:
+  - "Speaker_id_1"
+  - "Speaker_id_2"
+
+columns:
+  audio_path:
+    source_column: "Audio_File_Path"
+    dtype: "file_path"
+    file_extension: ".wav"
+  transcription:
+    source_column: "Transcript_File_Path"
+    dtype: "file_content"
+    file_extension: ".txt"
+  speaker_id:
+    source_column: "Speaker_ID"
+```
+
+The `file_content` dtype reuses the same path resolution as `file_path`
+(`base_audio_path`, `file_extension`, `path_match_strategy`, `path_template`)
+but returns the file's text content instead of the resolved path.
+
 ### Multi-split schema
 
 ```yaml

--- a/docs/schema_documentation.md
+++ b/docs/schema_documentation.md
@@ -195,6 +195,7 @@ columns:
 |---|---|
 | `string` | Cast to `str` (default). |
 | `file_path` | Resolve to an absolute path. By default this is `dataset_root / base_audio_path / value`, but the loader can also search one or more `base_audio_path` roots when `path_match_strategy` is set, or render filenames and directory roots from metadata columns with `path_template` and templated `base_audio_path` entries. |
+| `file_content` | Like `file_path`, but instead of keeping the resolved path, reads the file and returns its text content. Useful when the index stores paths to transcription files rather than inline text. Supports the same resolution options (`base_audio_path`, `file_extension`, `path_match_strategy`, `path_template`). |
 | `category` | Cast to pandas `Categorical`. |
 | `int` | Numeric coercion → nullable `Int64`. |
 | `float` | Numeric coercion → `float64`. |

--- a/src/datacollective/schema_loaders/base.py
+++ b/src/datacollective/schema_loaders/base.py
@@ -378,7 +378,16 @@ class BaseSchemaLoader(abc.ABC):
         self, value: object, col_map: ColumnMapping, row: pd.Series | None = None
     ) -> str:
         """Resolve a file path (like ``file_path`` dtype) and return its text content."""
-        resolved = self._resolve_file_path(value, col_map, row)
+        if pd.isna(value):  # if missing value, skip loading
+            return str(value)
+
+        # Remove whitespaces in the path
+        raw = str(value).strip()
+        parts = Path(raw).parts
+        if parts:
+            raw = str(Path(*[p.strip() for p in parts]))
+
+        resolved = self._resolve_file_path(raw, col_map, row)
         path = Path(resolved)
         if path.is_file():
             return path.read_text(encoding=self.schema.encoding).strip()

--- a/src/datacollective/schema_loaders/base.py
+++ b/src/datacollective/schema_loaders/base.py
@@ -174,6 +174,13 @@ class BaseSchemaLoader(abc.ABC):
                     ),
                     axis=1,
                 )
+            elif col_map.dtype == "file_content":
+                series = raw_df.apply(
+                    lambda row, _col_map=col_map, _source=resolved_source: (
+                        self._load_file_content(row[_source], _col_map, row)
+                    ),
+                    axis=1,
+                )
             elif col_map.dtype == "category":
                 series = series.astype("category")
             elif col_map.dtype == "int":
@@ -366,6 +373,16 @@ class BaseSchemaLoader(abc.ABC):
         if direct_candidates:
             return str(direct_candidates[0])
         return raw_value
+
+    def _load_file_content(
+        self, value: object, col_map: ColumnMapping, row: pd.Series | None = None
+    ) -> str:
+        """Resolve a file path (like ``file_path`` dtype) and return its text content."""
+        resolved = self._resolve_file_path(value, col_map, row)
+        path = Path(resolved)
+        if path.is_file():
+            return path.read_text(encoding=self.schema.encoding).strip()
+        return resolved
 
     def _build_direct_file_candidates(
         self,

--- a/tests/schema_loaders/tasks/test_asr_loader.py
+++ b/tests/schema_loaders/tasks/test_asr_loader.py
@@ -463,6 +463,54 @@ class TestASRIndexBased:
         df = ASRLoader(schema, tmp_path).load()
         assert len(df) == 1
 
+    def test_file_content_dtype_reads_text_file(self, tmp_path: Path) -> None:
+        _write_tsv(
+            tmp_path / "index.csv",
+            "audio,transcript\nclip.wav,transcripts/clip.txt\n",
+        )
+        txt_path = tmp_path / "transcripts" / "clip.txt"
+        txt_path.parent.mkdir()
+        txt_path.write_text("hello world\n", encoding="utf-8")
+
+        schema = DatasetSchema(
+            dataset_id="ds",
+            task="ASR",
+            format="csv",
+            index_file="index.csv",
+            columns={
+                "audio": ColumnMapping(source_column="audio", dtype="file_path"),
+                "text": ColumnMapping(source_column="transcript", dtype="file_content"),
+            },
+        )
+        df = ASRLoader(schema, tmp_path).load()
+        assert df["text"].iloc[0] == "hello world"
+
+    def test_file_content_dtype_with_file_extension(self, tmp_path: Path) -> None:
+        _write_tsv(
+            tmp_path / "index.csv",
+            "audio,transcript\nclip.wav,transcripts/clip\n",
+        )
+        txt_path = tmp_path / "transcripts" / "clip.txt"
+        txt_path.parent.mkdir()
+        txt_path.write_text("resolved with extension\n", encoding="utf-8")
+
+        schema = DatasetSchema(
+            dataset_id="ds",
+            task="ASR",
+            format="csv",
+            index_file="index.csv",
+            columns={
+                "audio": ColumnMapping(source_column="audio", dtype="file_path"),
+                "text": ColumnMapping(
+                    source_column="transcript",
+                    dtype="file_content",
+                    file_extension=".txt",
+                ),
+            },
+        )
+        df = ASRLoader(schema, tmp_path).load()
+        assert df["text"].iloc[0] == "resolved with extension"
+
 
 class TestASRMultiSplit:
     def test_load_multiple_splits(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Allow reading the file contents of a reference file path directly into the dataframe

For example:
> When the index file stores paths to transcription files instead of inline text, use `dtype: "file_content"` to read the file contents directly into the DataFrame