### PR TITLE
Remove upload limit, change to warning

### DIFF
--- a/docs/upload.md
+++ b/docs/upload.md
@@ -22,7 +22,7 @@ Before uploading, ensure you have:
 - An API key from the Mozilla Data Collective [dashboard](https://mozilladatacollective.com/api-reference)
 - Your dataset packaged as an archive file (`.tar.gz`, uploads use `application/gzip`)
 - All the required metadata for the dataset submission
-- Dataset archives must be **80GB or less**
+- Where a dataset archive is larger than 80GB, you will receive a warning notice on upload. The upload will still proceed, but you must contact support@mozilladatacollective.com if 
 
 ### Configuration
 

--- a/src/datacollective/upload.py
+++ b/src/datacollective/upload.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings 
+
 from pathlib import Path
 
 from datacollective.logging_utils import (
@@ -8,7 +10,7 @@ from datacollective.logging_utils import (
 )
 from datacollective.upload_utils import (
     UploadState,
-    MAX_UPLOAD_BYTES,
+    LARGE_UPLOAD_WARNING_BYTES,
     _default_state_path,
     _load_or_create_state,
     _expected_parts,
@@ -56,8 +58,11 @@ def upload_dataset_file(
     file_size = path.stat().st_size
     if file_size <= 0:
         raise ValueError("`file_path` must point to a non-empty file")
-    if file_size > MAX_UPLOAD_BYTES:
-        raise ValueError("`file_path` exceeds the 80GB upload limit")
+    if file_size > LARGE_UPLOAD_WARNING_BYTES:
+        warnings.warn(
+        "WARNING: We have detected that you are uploading a file larger than 80GB. "
+        "Please ensure you contact support@mozilladatacollective.com so that we can assist you."
+    )
 
     final_filename = path.name
 

--- a/src/datacollective/upload_utils.py
+++ b/src/datacollective/upload_utils.py
@@ -32,7 +32,6 @@ DEFAULT_MIME_TYPE = "application/gzip"
 # used as a warning threshold not a hard limit, as the API may support larger uploads depending on configuration
 LARGE_UPLOAD_WARNING_BYTES = 80 * 1000 * 1000 * 1000  # 80 GB warning threshold
 
-
 class UploadSession(NonEmptyStrModel):
     fileUploadId: str
     uploadId: str
@@ -235,7 +234,7 @@ def _init_progress_bar(
 ) -> ProgressBar | None:
     if not show_progress:
         return None
-    progress_bar = ProgressBar(file_size)
+    progress_bar = ProgressBar(file_size, bar_length=30)
     if already_uploaded > 0:
         progress_bar.update(already_uploaded * part_size)
         progress_bar._display()

--- a/src/datacollective/upload_utils.py
+++ b/src/datacollective/upload_utils.py
@@ -28,7 +28,9 @@ RETRY_BACKOFF_SECONDS = 2
 
 DEFAULT_PART_SIZE = 5 * 1024 * 1024  # 5 MB default part size to upload chunk by chunk
 DEFAULT_MIME_TYPE = "application/gzip"
-MAX_UPLOAD_BYTES = 150 * 1000 * 1000 * 1000  # 150 GB
+
+# used as a warning threshold not a hard limit, as the API may support larger uploads depending on configuration
+LARGE_UPLOAD_WARNING_BYTES = 80 * 1000 * 1000 * 1000  # 80 GB warning threshold
 
 
 class UploadSession(NonEmptyStrModel):
@@ -41,7 +43,7 @@ class UploadState(NonEmptyStrModel):
     submissionId: str
     fileUploadId: str
     uploadId: str
-    fileSize: int = Field(..., gt=0, le=MAX_UPLOAD_BYTES)
+    fileSize: int = Field(..., gt=0)
     partSize: int = Field(..., gt=0)
     filename: str
     mimeType: str
@@ -58,7 +60,7 @@ class PresignedPartUrl(NonEmptyStrModel):
 class _UploadInitiatePayload(NonEmptyStrModel):
     submissionId: str
     filename: str
-    fileSize: int = Field(..., gt=0, le=MAX_UPLOAD_BYTES)
+    fileSize: int = Field(..., gt=0)
     mimeType: str
 
 


### PR DESCRIPTION
```
$ pytest tests/test_upload_utils.py tests/test_upload_state.py -v
===================================== test session starts =====================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /home/kathyreid/datacollective-python/bin/python3
cachedir: .pytest_cache
rootdir: /home/kathyreid/datacollective-python
configfile: pyproject.toml
collected 4 items                                                                             

tests/test_upload_utils.py::test_upload_state_round_trip PASSED                         [ 25%]
tests/test_upload_utils.py::test_load_upload_state_returns_none_for_invalid_payload PASSED [ 50%]
tests/test_upload_state.py::test_upload_dataset_file_rejects_missing_file PASSED        [ 75%]
tests/test_upload_state.py::test_upload_dataset_file_rejects_empty_file PASSED          [100%]

====================================== 4 passed in 0.70s ======================================

```