### PR TITLE
Add visibility and showContactInfo fields in dataset submission

### DIFF
--- a/docs/demo_upload.py
+++ b/docs/demo_upload.py
@@ -2,6 +2,7 @@ from datacollective import (
     DatasetSubmission,
     License,
     Task,
+    Visibility,
     create_submission_with_upload,
 )
 
@@ -33,6 +34,8 @@ submission = DatasetSubmission(
     ethicalReviewProcess="Describe the ethical review process that was "
     "followed for this dataset, including any approvals "
     "or considerations related to data collection and usage.",
+    showContactInfo=True,  # Whether to publicly display the contact information above
+    visibility=Visibility.PUBLIC,  # public | private | restricted
     exclusivityOptOut=True,  # True = dataset is not exclusive to Data Collective (can be found elsewhere),
     # False = dataset is exclusively shared in Mozilla Data Collective
     agreeToSubmit=True,  # True = You confirm that you have the right to submit this dataset and that all information provided in the datasheet is accurate. Required to be true to complete the submission

--- a/docs/demo_upload.py
+++ b/docs/demo_upload.py
@@ -34,7 +34,7 @@ submission = DatasetSubmission(
     ethicalReviewProcess="Describe the ethical review process that was "
     "followed for this dataset, including any approvals "
     "or considerations related to data collection and usage.",
-    showContactInfo=True,  # Whether to publicly display the contact information above
+    showContactInfo=False,  # Whether to publicly display the contact information above
     visibility=Visibility.PUBLIC,  # public | private | restricted
     exclusivityOptOut=True,  # True = dataset is not exclusive to Data Collective (can be found elsewhere),
     # False = dataset is exclusively shared in Mozilla Data Collective

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,7 +112,13 @@ The SDK supports creating dataset submissions and uploading files with resumable
 The upload state is stored in a JSON file alongside the archive so interrupted uploads can resume automatically.
 
 ```python
-from datacollective import DatasetSubmission, License, Task, create_submission_with_upload
+from datacollective import (
+    DatasetSubmission,
+    License,
+    Task,
+    Visibility,
+    create_submission_with_upload,
+)
 
 submission = DatasetSubmission(
     name="Dataset Name",
@@ -142,6 +148,8 @@ submission = DatasetSubmission(
     ethicalReviewProcess="Describe the ethical review process that was "
                          "followed for this dataset, including any approvals "
                          "or considerations related to data collection and usage.",
+    showContactInfo=True,  # Whether to publicly display the contact information above
+    visibility=Visibility.PUBLIC,  # public | private | restricted
     exclusivityOptOut=False,  # True = This dataset is non-exclusive to Mozilla Data Collective, 
                               # False = Dataset is exclusively hosted in Mozilla Data Collective
     agreeToSubmit=True,  # True = You confirm that you have the right to submit this dataset and 

--- a/docs/index.md
+++ b/docs/index.md
@@ -148,7 +148,7 @@ submission = DatasetSubmission(
     ethicalReviewProcess="Describe the ethical review process that was "
                          "followed for this dataset, including any approvals "
                          "or considerations related to data collection and usage.",
-    showContactInfo=True,  # Whether to publicly display the contact information above
+    showContactInfo=False,  # Whether to publicly display the contact information above
     visibility=Visibility.PUBLIC,  # public | private | restricted
     exclusivityOptOut=False,  # True = This dataset is non-exclusive to Mozilla Data Collective, 
                               # False = Dataset is exclusively hosted in Mozilla Data Collective

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -22,7 +22,7 @@ Before uploading, ensure you have:
 - An API key from the Mozilla Data Collective [dashboard](https://mozilladatacollective.com/api-reference)
 - Your dataset packaged as an archive file (`.tar.gz`, uploads use `application/gzip`)
 - All the required metadata for the dataset submission
-- Dataset archives must be **80GB or less**
+- Dataset archives must be **150GB or less**
 
 ### Configuration
 

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -43,7 +43,13 @@ MDC_API_KEY=your-api-key-here
 The simplest way to upload a dataset is using `create_submission_with_upload`, which handles the entire workflow in a single call:
 
 ```python
-from datacollective import DatasetSubmission, License, Task, create_submission_with_upload
+from datacollective import (
+    DatasetSubmission,
+    License,
+    Task,
+    Visibility,
+    create_submission_with_upload,
+)
 
 submission = DatasetSubmission(
     name="Dataset Name",
@@ -73,6 +79,8 @@ submission = DatasetSubmission(
     ethicalReviewProcess="Describe the ethical review process that was "
                          "followed for this dataset, including any approvals "
                          "or considerations related to data collection and usage.",
+    showContactInfo=True,  # Whether to publicly display the contact information above
+    visibility=Visibility.PUBLIC,  # public | private | restricted
     exclusivityOptOut=False,  # True = This dataset is non-exclusive to Mozilla Data Collective, 
                               # False = Dataset is exclusively hosted in Mozilla Data Collective
     agreeToSubmit=True,  # True = You confirm that you have the right to submit this dataset and 
@@ -89,6 +97,9 @@ print(response)
 ```
 
 For predefined licenses, pass `licenseAbbreviation=License.<VALUE>` and leave `licenseUrl` and `license` unset. For a custom license, pass a custom string to `license` and optionally include `licenseUrl` and `licenseAbbreviation`.
+
+### Visibility
+- `visibility` controls who can access the dataset and must be one of the `Visibility` enum values: `Visibility.PUBLIC`, `Visibility.PRIVATE`, or `Visibility.RESTRICTED`.
 
 ## Upload a New File Version to an Approved Dataset
 
@@ -134,6 +145,8 @@ To complete the submission process, the submission **must** include at least all
 - `forbiddenUsage`
 - `pointOfContactFullName`
 - `pointOfContactEmail`
+- `showContactInfo`
+- `visibility`
 - `agreeToSubmit=True`
 - `fileUploadId`
 
@@ -190,7 +203,13 @@ For this step, you will need the `fileUploadId` from the upload response above, 
 At this step, you can also update any other metadata fields.
 
 ```python
-from datacollective import DatasetSubmission, License, Task, update_submission
+from datacollective import (
+    DatasetSubmission,
+    License,
+    Task,
+    Visibility,
+    update_submission,
+)
 
 update_fields = DatasetSubmission(
     task=Task.ASR,
@@ -201,6 +220,8 @@ update_fields = DatasetSubmission(
     forbiddenUsage="Do not use for unlawful purposes.",
     pointOfContactFullName="Jane Doe",
     pointOfContactEmail="jane@example.com",
+    showContactInfo=True,
+    visibility=Visibility.PUBLIC,
     fileUploadId=upload_state.fileUploadId,
     # ... other metadata fields ...
 )

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -79,7 +79,7 @@ submission = DatasetSubmission(
     ethicalReviewProcess="Describe the ethical review process that was "
                          "followed for this dataset, including any approvals "
                          "or considerations related to data collection and usage.",
-    showContactInfo=True,  # Whether to publicly display the contact information above
+    showContactInfo=False,  # Whether to publicly display the contact information above
     visibility=Visibility.PUBLIC,  # public | private | restricted
     exclusivityOptOut=False,  # True = This dataset is non-exclusive to Mozilla Data Collective, 
                               # False = Dataset is exclusively hosted in Mozilla Data Collective
@@ -217,7 +217,7 @@ update_fields = DatasetSubmission(
     forbiddenUsage="Do not use for unlawful purposes.",
     pointOfContactFullName="Jane Doe",
     pointOfContactEmail="jane@example.com",
-    showContactInfo=True,
+    showContactInfo=False,
     visibility=Visibility.PUBLIC,
     # ... other metadata fields ...
 )

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -148,9 +148,8 @@ To complete the submission process, the submission **must** include at least all
 - `showContactInfo`
 - `visibility`
 - `agreeToSubmit=True`
-- `fileUploadId`
 
-The `fileUploadId` is only available after a successful file upload and is required to link the uploaded archive to the submission. 
+A completed file upload must also be attached to the submission before it can be submitted for review. The uploaded archive is linked to the submission automatically when the multipart upload completes (the upload is started with the submission's ID). 
 
 ## Step-by-Step Upload
 
@@ -198,9 +197,7 @@ print(f"Upload complete! File Upload ID: {upload_state.fileUploadId}")
 
 ### Step 3: Update Submission Metadata
 
-For this step, you will need the `fileUploadId` from the upload response above, which is required to link the uploaded file to your submission. Without this ID, you won't be able to proceed to the submission step. If you no longer have access to it, you will need to re-upload the file to get a new `fileUploadId`.
-
-At this step, you can also update any other metadata fields.
+Fill in the datasheet fields for your submission.
 
 ```python
 from datacollective import (
@@ -222,7 +219,6 @@ update_fields = DatasetSubmission(
     pointOfContactEmail="jane@example.com",
     showContactInfo=True,
     visibility=Visibility.PUBLIC,
-    fileUploadId=upload_state.fileUploadId,
     # ... other metadata fields ...
 )
 

--- a/src/datacollective/__init__.py
+++ b/src/datacollective/__init__.py
@@ -6,7 +6,12 @@ from datacollective.datasets import (
     load_dataset,
     save_dataset_to_disk,
 )
-from datacollective.models import DatasetSubmission, License, Task
+from datacollective.models import (
+    DatasetSubmission,
+    License,
+    Task,
+    Visibility,
+)
 from datacollective.submissions import (
     create_submission_draft,
     create_submission_with_upload,
@@ -28,6 +33,7 @@ __all__ = [
     "DatasetSubmission",
     "License",
     "Task",
+    "Visibility",
     "__version__",
 ]
 

--- a/src/datacollective/api_utils.py
+++ b/src/datacollective/api_utils.py
@@ -212,12 +212,18 @@ def _prepare_download_headers(
     return {}, 0
 
 
-def _format_bytes(bytes_val: int) -> str:
-    """Format bytes into a human-readable string."""
+def _format_bytes(bytes_val: int, base: int = 1024) -> str:
+    """Format bytes into a human-readable string.
+
+    Args:
+        bytes_val: Number of bytes.
+        base: Unit base to divide by — ``1024`` for binary units or ``1000``
+            for decimal (SI) units. Defaults to ``1024``.
+    """
     units = ["B", "KB", "MB", "GB", "TB", "PB"]
     value = float(bytes_val)
     for unit in units:
-        if value < 1024.0 or unit == units[-1]:
+        if value < base or unit == units[-1]:
             return f"{value:.1f} {unit}"
-        value /= 1024.0
+        value /= base
     return ""

--- a/src/datacollective/models.py
+++ b/src/datacollective/models.py
@@ -307,7 +307,7 @@ def _build_final_submission_error(
 ) -> str:
     message = (
         "Cannot submit dataset. Missing required fields for final submission: "
-        f"{', '.join(missing_items)}. Please update your DatasetSubmission model"
+        f"{', '.join(missing_items)}. Please update your DatasetSubmission model "
         f"with the appropriate fields."
     )
     if missing_file_upload_id:

--- a/src/datacollective/models.py
+++ b/src/datacollective/models.py
@@ -307,10 +307,11 @@ def _build_final_submission_error(
 ) -> str:
     message = (
         "Cannot submit dataset. Missing required fields for final submission: "
-        f"{', '.join(missing_items)}."
+        f"{', '.join(missing_items)}. Please update your DatasetSubmission model"
+        f"with the appropriate fields."
     )
     if missing_file_upload_id:
-        message += " Upload the dataset file first to get a `fileUploadId`."
+        message += " Upload the dataset file before submitting."
     return message
 
 

--- a/src/datacollective/models.py
+++ b/src/datacollective/models.py
@@ -275,8 +275,6 @@ UPDATE_FIELDS = {
     "showContactInfo",
     "visibility",
     "exclusivityOptOut",
-    "fileUploadId",
-    "agreeToSubmit",
 }
 SUBMIT_FIELDS = {"agreeToSubmit"}
 

--- a/src/datacollective/models.py
+++ b/src/datacollective/models.py
@@ -21,7 +21,7 @@ class Task(str, Enum):
     NA = "N/A"
     NLP = "NLP"
     ASR = "ASR"
-    LI = "LI"
+    LID = "LID"
     TTS = "TTS"
     MT = "MT"
     LM = "LM"
@@ -32,7 +32,7 @@ class Task(str, Enum):
     RAG = "RAG"
     CV = "CV"
     ML = "ML"
-    OTHER = "Other"
+    OTH = "OTH"
 
 
 class License(str, Enum):
@@ -63,6 +63,14 @@ class License(str, Enum):
     OPUBL_1_0 = "OPUBL-1.0"
     OGDL_TAIWAN_1_0 = "OGDL-Taiwan-1.0"
     UNLICENSE = "Unlicense"
+
+
+class Visibility(str, Enum):
+    """Dataset visibility levels."""
+
+    PUBLIC = "public"
+    PRIVATE = "private"
+    RESTRICTED = "restricted"
 
 
 class NonEmptyStrModel(BaseModel):
@@ -150,6 +158,14 @@ class DatasetSubmission(NonEmptyStrModel):
     ethicalReviewProcess: str | None = Field(
         None, description="Description of ethical review conducted."
     )
+    showContactInfo: bool | None = Field(
+        None,
+        description="Whether to publicly display the dataset contact information.",
+    )
+    visibility: Visibility | None = Field(
+        None,
+        description="Dataset visibility: `public`, `private`, or `restricted`.",
+    )
     exclusivityOptOut: bool | None = Field(
         None,
         description="True if dataset is non-exclusive; False if hosted exclusively on Mozilla Data Collective (see https://mozilladatacollective.com/terms/providers#appendix-1).",
@@ -223,6 +239,8 @@ FINAL_SUBMISSION_REQUIRED_FIELDS = (
     "forbiddenUsage",
     "pointOfContactFullName",
     "pointOfContactEmail",
+    "showContactInfo",
+    "visibility",
 )
 FINAL_SUBMISSION_LOCAL_FIELDS = set(FINAL_SUBMISSION_REQUIRED_FIELDS) | {
     "licenseAbbreviation",
@@ -254,6 +272,8 @@ UPDATE_FIELDS = {
     "createdByEmail",
     "intendedUsage",
     "ethicalReviewProcess",
+    "showContactInfo",
+    "visibility",
     "exclusivityOptOut",
     "fileUploadId",
     "agreeToSubmit",

--- a/src/datacollective/submissions.py
+++ b/src/datacollective/submissions.py
@@ -150,6 +150,10 @@ def create_submission_with_upload(
         enable_logging=enable_logging,
     )
 
+    # The uploaded file is linked to the submission automatically when the
+    # multipart upload completes (the upload was started with `submissionId`),
+    # so `fileUploadId` is not sent on the metadata PATCH. We still record it on
+    # the model to satisfy the local completeness check below.
     submission.fileUploadId = upload_state.fileUploadId
     _validate_final_submission_fields(submission, require_file_upload_id=True)
 

--- a/src/datacollective/upload.py
+++ b/src/datacollective/upload.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from datacollective.api_utils import _format_bytes
 from datacollective.logging_utils import (
     _enable_logging,
     get_logger,
@@ -57,7 +58,10 @@ def upload_dataset_file(
     if file_size <= 0:
         raise ValueError("`file_path` must point to a non-empty file")
     if file_size > MAX_UPLOAD_BYTES:
-        raise ValueError("`file_path` exceeds the 80GB upload limit")
+        raise ValueError(
+            f"`file_path` exceeds the {_format_bytes(MAX_UPLOAD_BYTES, base=1000)} "
+            "upload limit"
+        )
 
     final_filename = path.name
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -92,7 +92,7 @@ def sample_dataset_submission(name: str) -> DatasetSubmission:
         createdByEmail="sdk-tests@example.com",
         intendedUsage="Exercise the upload and submission lifecycle in live tests.",
         ethicalReviewProcess="No review required for synthetic test data.",
-        showContactInfo=True,
+        showContactInfo=False,
         visibility=Visibility.PUBLIC,
         exclusivityOptOut=True,
         agreeToSubmit=True,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -9,7 +9,7 @@ from requests import HTTPError
 from requests import Timeout
 
 from datacollective.errors import RateLimitError
-from datacollective.models import DatasetSubmission, License, Task
+from datacollective.models import DatasetSubmission, License, Task, Visibility
 
 
 LIVE_TEST_SKIP_REASON = (
@@ -92,6 +92,8 @@ def sample_dataset_submission(name: str) -> DatasetSubmission:
         createdByEmail="sdk-tests@example.com",
         intendedUsage="Exercise the upload and submission lifecycle in live tests.",
         ethicalReviewProcess="No review required for synthetic test data.",
+        showContactInfo=True,
+        visibility=Visibility.PUBLIC,
         exclusivityOptOut=True,
         agreeToSubmit=True,
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,12 @@
 import pytest
 from pydantic import ValidationError
 
-from datacollective.models import DatasetSubmission, License, Task
+from datacollective.models import (
+    DatasetSubmission,
+    License,
+    Task,
+    Visibility,
+)
 
 
 def test_submission_rejects_empty_strings() -> None:
@@ -47,7 +52,7 @@ def test_task_enum_all_values() -> None:
         "N/A",
         "NLP",
         "ASR",
-        "LI",
+        "LID",
         "TTS",
         "MT",
         "LM",
@@ -58,7 +63,7 @@ def test_task_enum_all_values() -> None:
         "RAG",
         "CV",
         "ML",
-        "Other",
+        "OTH",
     }
     assert {t.value for t in Task} == expected
 
@@ -74,8 +79,8 @@ def test_task_na_value() -> None:
 
 
 def test_task_other_value() -> None:
-    model = DatasetSubmission(task="Other")
-    assert model.task == Task.OTHER
+    model = DatasetSubmission(task="OTH")
+    assert model.task == Task.OTH
 
 
 def test_task_rejects_invalid_value() -> None:
@@ -123,3 +128,26 @@ def test_empty_license_abbreviation_requires_or_uses_license_name() -> None:
     )
     assert model.licenseAbbreviation == ""
     assert model.license == "Mozilla Research License"
+
+
+def test_visibility_enum_values() -> None:
+    assert {v.value for v in Visibility} == {"public", "private", "restricted"}
+
+
+def test_visibility_accepted_by_enum_and_string() -> None:
+    assert DatasetSubmission(visibility=Visibility.PRIVATE).visibility == (
+        Visibility.PRIVATE
+    )
+    assert DatasetSubmission(visibility="restricted").visibility == (
+        Visibility.RESTRICTED
+    )
+
+
+def test_visibility_rejects_invalid_value() -> None:
+    with pytest.raises(ValidationError):
+        DatasetSubmission(visibility="internal")
+
+
+def test_show_contact_info_accepts_boolean() -> None:
+    assert DatasetSubmission(showContactInfo=True).showContactInfo is True
+    assert DatasetSubmission(showContactInfo=False).showContactInfo is False

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -20,7 +20,7 @@ def _build_complete_submission(
         "forbiddenUsage": "Do not use for unlawful purposes.",
         "pointOfContactFullName": "Jane Doe",
         "pointOfContactEmail": "jane@example.com",
-        "showContactInfo": True,
+        "showContactInfo": False,
         "visibility": Visibility.PUBLIC,
         "agreeToSubmit": True,
     }

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import datacollective.submissions as submissions_module
 import pytest
 
-from datacollective.models import DatasetSubmission, License, Task
+from datacollective.models import DatasetSubmission, License, Task, Visibility
 
 
 def _build_complete_submission(
@@ -20,6 +20,8 @@ def _build_complete_submission(
         "forbiddenUsage": "Do not use for unlawful purposes.",
         "pointOfContactFullName": "Jane Doe",
         "pointOfContactEmail": "jane@example.com",
+        "showContactInfo": True,
+        "visibility": Visibility.PUBLIC,
         "agreeToSubmit": True,
     }
     if file_upload_id is not None:

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -82,8 +82,9 @@ def test_submit_submission_requires_file_upload_id_for_local_final_submission(
         )
 
     assert str(exc_info.value) == (
-        "Cannot submit dataset. Missing required fields for final submission: "
-        "`fileUploadId`. Upload the dataset file first to get a `fileUploadId`."
+        "Cannot submit dataset. Missing required fields for final submission: `fileUploadId`. "
+        "Please update your DatasetSubmission model with the appropriate fields. "
+        "Upload the dataset file before submitting."
     )
 
 


### PR DESCRIPTION
Changes

  - Add `visibility` field (Visibility enum: public / private / restricted) to DatasetSubmission
  - Add `showContactInfo` field (boolean) to DatasetSubmission.
  - Fix Task enum values to match the updated spec: LI → LID, and OTHER = "Other" → OTH = "OTH".
  - `_format_bytes` now takes a base argument (1024 binary / 1000 decimal) and the "upload exceeds limit" error uses it so it renders as 150.0 GB instead of a raw byte count.
  - Docs: documented upload limit corrected to 150GB; upload.md and demo_upload.py examples and required-fields list updated for visibility / showContactInfo.

  Tests

  - (shoehorned) Updated Task enum expectations (LID/OTH) and submission test fixtures
  - added Visibility coverage.