### PR TITLE
Enable user to set part size

### DIFF
--- a/docs/upload.md
+++ b/docs/upload.md
@@ -250,6 +250,30 @@ submission = response["submission"]
 print(f"Submission status: {submission['status']}")
 ```
 
+## Tuning the Part Size
+
+Uploads are **multipart**: the file is split into fixed-size chunks ("parts") that are uploaded one by one. Both `upload_dataset_file` and `create_submission_with_upload` accept a `part_size` argument (in bytes) to control this. It defaults to **10 MB**.
+
+```python
+upload_dataset_file(
+    file_path="/path/to/dataset.tar.gz",
+    submission_id=submission_id,
+    part_size=20 * 1024 * 1024,  # 20 MB parts
+)
+```
+
+**Why change it?**
+
+- **Larger parts** mean fewer parts overall, so fewer requests and less per-part overhead — useful on fast, reliable connections and for very large files (see the limit below).
+- **Smaller parts** give finer-grained resume: after an interruption only the unfinished part is re-uploaded, not a large chunk. Handy on slow or flaky connections. Note that the storage backend requires every part except the last to be at least **5 MB**, so that is the practical lower bound.
+
+**The `MAX_UPLOAD_PARTS` limit**
+
+A single upload can have at most **10,000 parts**. This means `part_size` must be large enough that `ceil(file_size / part_size) ≤ 10,000`. The SDK checks this up front and raises a `ValueError` telling you the minimum `part_size` to use, rather than failing partway through the upload. For example, a 1 TB file needs parts of at least ~100 MB.
+
+> [!NOTE]
+> When **resuming** an interrupted upload, `part_size` is ignored — the SDK reuses the part size recorded in the state file so the already-uploaded parts stay valid.
+
 ## Resumable Uploads
 
 The SDK automatically handles interrupted uploads using a state file.

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -22,7 +22,6 @@ Before uploading, ensure you have:
 - An API key from the Mozilla Data Collective [dashboard](https://mozilladatacollective.com/api-reference)
 - Your dataset packaged as an archive file (`.tar.gz`, uploads use `application/gzip`)
 - All the required metadata for the dataset submission
-- Dataset archives must be **80GB or less**
 
 ### Configuration
 

--- a/src/datacollective/submissions.py
+++ b/src/datacollective/submissions.py
@@ -18,7 +18,7 @@ from datacollective.models import (
     SUBMIT_FIELDS,
 )
 from datacollective.upload import upload_dataset_file
-from datacollective.upload_utils import _resolve_upload_state
+from datacollective.upload_utils import _resolve_upload_state, DEFAULT_PART_SIZE
 
 logger = get_logger(__name__)
 
@@ -103,6 +103,7 @@ def create_submission_with_upload(
     submission: DatasetSubmission,
     state_path: str | None = None,
     enable_logging: bool = False,
+    part_size: int = DEFAULT_PART_SIZE,
 ) -> dict[str, Any]:
     """
     Single point function to create a submission, upload a file, update metadata, and submit for review.
@@ -113,6 +114,8 @@ def create_submission_with_upload(
         submission: Dataset submission model with metadata fields.
         state_path: Optional path to persist upload state.
         enable_logging: Whether to enable detailed logging during the process.
+        part_size: Multipart part size in bytes. Ignored when resuming an existing upload,
+            which keeps the part size recorded in its state file.
     """
     _enable_logging(enable_logging)
 
@@ -148,6 +151,7 @@ def create_submission_with_upload(
         submission_id=submission_id,
         state_path=state_path,
         enable_logging=enable_logging,
+        part_size=part_size,
     )
 
     submission.fileUploadId = upload_state.fileUploadId

--- a/src/datacollective/upload.py
+++ b/src/datacollective/upload.py
@@ -19,6 +19,8 @@ from datacollective.upload_utils import (
     _save_upload_state,
     _complete_upload,
     _cleanup_state_file,
+    _ensure_part_size_is_valid,
+    DEFAULT_PART_SIZE,
 )
 
 logger = get_logger(__name__)
@@ -30,6 +32,7 @@ def upload_dataset_file(
     state_path: str | None = None,
     show_progress: bool = True,
     enable_logging: bool = False,
+    part_size: int = DEFAULT_PART_SIZE,
 ) -> UploadState:
     """
     Upload a dataset file using multipart uploads with resumable state.
@@ -46,6 +49,8 @@ def upload_dataset_file(
             `<filename>.mdc-upload.json` alongside the archive.
         enable_logging: Whether to enable detailed logging during the upload.
         show_progress: Whether to show a progress bar during upload.
+        part_size: Multipart part size in bytes. Ignored when resuming an
+            existing upload, which keeps the part size recorded in its state file.
     """
     path = Path(file_path)
     _enable_logging(enable_logging)
@@ -57,7 +62,9 @@ def upload_dataset_file(
     if file_size <= 0:
         raise ValueError("`file_path` must point to a non-empty file")
     if file_size > MAX_UPLOAD_BYTES:
-        raise ValueError("`file_path` exceeds the 80GB upload limit")
+        raise ValueError("`file_path` exceeds the 150GB upload limit")
+
+    _ensure_part_size_is_valid(file_size, part_size)
 
     final_filename = path.name
 
@@ -68,6 +75,7 @@ def upload_dataset_file(
         submission_id=submission_id,
         final_filename=final_filename,
         file_size=file_size,
+        part_size=part_size,
     )
 
     expected_parts = _expected_parts(state.fileSize, state.partSize)

--- a/src/datacollective/upload.py
+++ b/src/datacollective/upload.py
@@ -8,7 +8,6 @@ from datacollective.logging_utils import (
 )
 from datacollective.upload_utils import (
     UploadState,
-    MAX_UPLOAD_BYTES,
     _default_state_path,
     _load_or_create_state,
     _expected_parts,
@@ -37,7 +36,7 @@ def upload_dataset_file(
     """
     Upload a dataset file using multipart uploads with resumable state.
 
-    Uploads are limited to 80GB and use the `application/gzip` MIME type.
+    Uploads use the `application/gzip` MIME type.
     Pass the submission ID of the target dataset submission. This works for
     both draft submissions and for uploading a new `.tar.gz` version to an
     already approved dataset submission.
@@ -61,8 +60,6 @@ def upload_dataset_file(
     file_size = path.stat().st_size
     if file_size <= 0:
         raise ValueError("`file_path` must point to a non-empty file")
-    if file_size > MAX_UPLOAD_BYTES:
-        raise ValueError("`file_path` exceeds the 150GB upload limit")
 
     _ensure_part_size_is_valid(file_size, part_size)
 

--- a/src/datacollective/upload_utils.py
+++ b/src/datacollective/upload_utils.py
@@ -30,6 +30,32 @@ DEFAULT_PART_SIZE = 5 * 1024 * 1024  # 5 MB default part size to upload chunk by
 DEFAULT_MIME_TYPE = "application/gzip"
 MAX_UPLOAD_BYTES = 150 * 1000 * 1000 * 1000  # 150 GB
 
+# Storage caps a multipart upload at 10.000 presigned parts
+MAX_UPLOAD_PARTS = 10_000
+
+
+def _ensure_part_size_is_valid(file_size: int, part_size: int) -> None:
+    """
+    Ensure the file does not require more than ``MAX_UPLOAD_PARTS`` parts.
+    For example, if MAX_UPLOADS_PARTS is 10.000 and file_size is 100 GB, the part
+    size must be minimum 10 MB, otherwise the upload will fail when requesting
+    presigned URLs for parts above the limit.
+
+    Raises a clear error up front instead of letting the storage backend reject
+    a part number above the presigned-URL limit mid-upload.
+    """
+    if part_size <= 0:
+        raise ValueError("`part_size` must be greater than 0")
+    required_parts = _expected_parts(file_size, part_size)
+    if required_parts > MAX_UPLOAD_PARTS:
+        min_part_size = int(math.ceil(file_size / MAX_UPLOAD_PARTS))
+        raise ValueError(
+            f"File requires {required_parts} parts at a part size of "
+            f"{_format_bytes(part_size)} for the whole file of {_format_bytes(file_size)},"
+            f" exceeding the limit of {MAX_UPLOAD_PARTS}. Increase the "
+            f"`part_size` argument to at least {_format_bytes(min_part_size)}."
+        )
+
 
 class UploadSession(NonEmptyStrModel):
     fileUploadId: str
@@ -75,7 +101,7 @@ class _CompleteUploadPayload(NonEmptyStrModel):
 
 
 def _initiate_upload(
-    submission_id: str, filename: str, file_size: int, mime_type: str
+    submission_id: str, filename: str, file_size: int, mime_type: str, part_size: int
 ) -> UploadSession:
     """
     Start a multipart upload for a dataset submission.
@@ -85,6 +111,7 @@ def _initiate_upload(
         filename: Name of the file to upload.
         file_size: Size of the file in bytes.
         mime_type: MIME type for the file.
+        part_size: Multipart part size in bytes to use for this upload.
     """
     payload = _UploadInitiatePayload(
         submissionId=submission_id,
@@ -95,11 +122,10 @@ def _initiate_upload(
     url = f"{_get_api_url()}/uploads"
     resp = _send_api_request("POST", url, json_body=payload.model_dump())
     data = dict(resp.json())
-    print(data)
     session_payload = {
         "fileUploadId": str(data.get("fileUploadId", "")),
         "uploadId": str(data.get("uploadId", "")),
-        "partSize": int(data.get("partSize", 0)) or DEFAULT_PART_SIZE,
+        "partSize": part_size,
     }
     try:
         return UploadSession.model_validate(session_payload)
@@ -180,6 +206,7 @@ def _load_or_create_state(
     submission_id: str,
     final_filename: str,
     file_size: int,
+    part_size: int,
 ) -> UploadState:
     state = _load_upload_state(state_file)
     if state:
@@ -196,7 +223,7 @@ def _load_or_create_state(
             f"Initiating upload for '{final_filename}' ({_format_bytes(file_size)})..."
         )
         session = _initiate_upload(
-            submission_id, final_filename, file_size, DEFAULT_MIME_TYPE
+            submission_id, final_filename, file_size, DEFAULT_MIME_TYPE, part_size
         )
         state = UploadState(
             submissionId=submission_id,

--- a/src/datacollective/upload_utils.py
+++ b/src/datacollective/upload_utils.py
@@ -29,22 +29,31 @@ RETRY_BACKOFF_SECONDS = 2
 DEFAULT_PART_SIZE = 10 * 1024 * 1024  # 10 MB default part size to upload chunk by chunk
 DEFAULT_MIME_TYPE = "application/gzip"
 
+# Storage requires every part except the last to be at least 5 MB
+MINIMUM_PART_SIZE = 5 * 1024 * 1024
 # Storage caps a multipart upload at 10.000 presigned parts
 MAX_UPLOAD_PARTS = 10_000
 
 
 def _ensure_part_size_is_valid(file_size: int, part_size: int) -> None:
     """
-    Ensure the file does not require more than ``MAX_UPLOAD_PARTS`` parts.
-    For example, if MAX_UPLOADS_PARTS is 10.000 and file_size is 100 GB, the part
-    size must be minimum 10 MB, otherwise the upload will fail when requesting
-    presigned URLs for parts above the limit.
+    Ensure the part size is valid for the upload.
+
+    The part size must be at least ``MINIMUM_PART_SIZE`` (the storage backend
+    rejects parts smaller than this, except the last one) and large enough that
+    the file does not require more than ``MAX_UPLOAD_PARTS`` parts. For example,
+    if MAX_UPLOAD_PARTS is 10.000 and file_size is 100 GB, the part size must be
+    minimum 10 MB, otherwise the upload will fail when requesting presigned URLs
+    for parts above the limit.
 
     Raises a clear error up front instead of letting the storage backend reject
-    a part number above the presigned-URL limit mid-upload.
+    an undersized part or a part number above the presigned-URL limit mid-upload.
     """
-    if part_size <= 0:
-        raise ValueError("`part_size` must be greater than 0")
+    if part_size < MINIMUM_PART_SIZE:
+        raise ValueError(
+            f"`part_size` must be at least {_format_bytes(MINIMUM_PART_SIZE)}, "
+            f"got {_format_bytes(part_size)}."
+        )
     required_parts = _expected_parts(file_size, part_size)
     if required_parts > MAX_UPLOAD_PARTS:
         min_part_size = int(math.ceil(file_size / MAX_UPLOAD_PARTS))

--- a/src/datacollective/upload_utils.py
+++ b/src/datacollective/upload_utils.py
@@ -28,7 +28,6 @@ RETRY_BACKOFF_SECONDS = 2
 
 DEFAULT_PART_SIZE = 5 * 1024 * 1024  # 5 MB default part size to upload chunk by chunk
 DEFAULT_MIME_TYPE = "application/gzip"
-MAX_UPLOAD_BYTES = 150 * 1000 * 1000 * 1000  # 150 GB
 
 # Storage caps a multipart upload at 10.000 presigned parts
 MAX_UPLOAD_PARTS = 10_000
@@ -67,7 +66,7 @@ class UploadState(NonEmptyStrModel):
     submissionId: str
     fileUploadId: str
     uploadId: str
-    fileSize: int = Field(..., gt=0, le=MAX_UPLOAD_BYTES)
+    fileSize: int = Field(..., gt=0)
     partSize: int = Field(..., gt=0)
     filename: str
     mimeType: str
@@ -84,7 +83,7 @@ class PresignedPartUrl(NonEmptyStrModel):
 class _UploadInitiatePayload(NonEmptyStrModel):
     submissionId: str
     filename: str
-    fileSize: int = Field(..., gt=0, le=MAX_UPLOAD_BYTES)
+    fileSize: int = Field(..., gt=0)
     mimeType: str
 
 

--- a/src/datacollective/upload_utils.py
+++ b/src/datacollective/upload_utils.py
@@ -26,7 +26,7 @@ UPLOAD_TIMEOUT = (20, 600)  # (20s connect timeout, 10min read timeout)
 MAX_UPLOAD_RETRIES = 3
 RETRY_BACKOFF_SECONDS = 2
 
-DEFAULT_PART_SIZE = 5 * 1024 * 1024  # 5 MB default part size to upload chunk by chunk
+DEFAULT_PART_SIZE = 10 * 1024 * 1024  # 10 MB default part size to upload chunk by chunk
 DEFAULT_MIME_TYPE = "application/gzip"
 
 # Storage caps a multipart upload at 10.000 presigned parts

--- a/tests/e2e/test_upload_e2e.py
+++ b/tests/e2e/test_upload_e2e.py
@@ -1,3 +1,4 @@
+import math
 from datetime import datetime
 from pathlib import Path
 
@@ -61,4 +62,38 @@ def test_upload_dataset_file_updates_approved_dataset_version(
     assert upload_state.filename == example_dataset_archive_path.name
     assert upload_state.parts
     assert upload_state.checksum
+    assert not state_path.exists(), "Upload state should be cleaned up after success"
+
+
+def test_upload_dataset_file_with_non_default_part_size(
+    tmp_path: Path,
+    live_api_env: None,
+    approved_dataset_submission_id: str,
+) -> None:
+    # The storage backend requires every part except the last to be >= 5 MB,
+    # so use a 5 MB part size (different from the 10 MB default) on a file just
+    # over that threshold to force a genuine two-part multipart upload.
+    part_size = 5 * 1024 * 1024  # 5 MB
+    file_size = int(part_size * 1.5)  # 7.5 MB
+    file_path = tmp_path / "custom-part-size-dataset.tar.gz"
+    file_path.write_bytes(b"\0" * file_size)
+    expected_parts = math.ceil(file_path.stat().st_size / part_size)
+    assert expected_parts == 2
+
+    state_path = tmp_path / "custom-part-size-upload-state.json"
+    upload_state = None
+    try:
+        upload_state = upload_dataset_file(
+            file_path=str(file_path),
+            submission_id=approved_dataset_submission_id,
+            state_path=str(state_path),
+            show_progress=False,
+            part_size=part_size,
+        )
+    except Exception as exc:  # noqa: BLE001
+        skip_if_rate_limited(exc)
+
+    assert upload_state is not None
+    assert upload_state.partSize == part_size
+    assert len(upload_state.parts) == expected_parts
     assert not state_path.exists(), "Upload state should be cleaned up after success"

--- a/tests/test_upload_utils.py
+++ b/tests/test_upload_utils.py
@@ -10,6 +10,7 @@ from datacollective.upload_utils import (
     _save_upload_state,
     _load_upload_state,
     _ensure_part_size_is_valid,
+    _expected_parts,
 )
 
 
@@ -63,3 +64,14 @@ def test_validate_part_count_rejects_too_many_parts() -> None:
 def test_validate_part_count_allows_fitting_file() -> None:
     file_size = DEFAULT_PART_SIZE * MAX_UPLOAD_PARTS
     _ensure_part_size_is_valid(file_size, DEFAULT_PART_SIZE)
+
+
+def test_validate_part_count_rejects_non_positive_part_size() -> None:
+    with pytest.raises(ValueError, match="greater than 0"):
+        _ensure_part_size_is_valid(1024, 0)
+
+
+def test_expected_parts_rounds_up_for_remainder() -> None:
+    # A trailing partial chunk must get its own part.
+    assert _expected_parts(file_size=250, part_size=100) == 3
+    assert _expected_parts(file_size=200, part_size=100) == 2

--- a/tests/test_upload_utils.py
+++ b/tests/test_upload_utils.py
@@ -67,7 +67,7 @@ def test_validate_part_count_allows_fitting_file() -> None:
 
 
 def test_validate_part_count_rejects_non_positive_part_size() -> None:
-    with pytest.raises(ValueError, match="greater than 0"):
+    with pytest.raises(ValueError, match="must be at least"):
         _ensure_part_size_is_valid(1024, 0)
 
 

--- a/tests/test_upload_utils.py
+++ b/tests/test_upload_utils.py
@@ -1,10 +1,15 @@
 from pathlib import Path
 
+import pytest
+
 from datacollective.models import UploadPart
 from datacollective.upload_utils import (
+    DEFAULT_PART_SIZE,
+    MAX_UPLOAD_PARTS,
     UploadState,
     _save_upload_state,
     _load_upload_state,
+    _ensure_part_size_is_valid,
 )
 
 
@@ -47,3 +52,14 @@ def test_load_upload_state_returns_none_for_invalid_payload(tmp_path: Path) -> N
     )
 
     assert _load_upload_state(state_path) is None
+
+
+def test_validate_part_count_rejects_too_many_parts() -> None:
+    file_size = DEFAULT_PART_SIZE * (MAX_UPLOAD_PARTS + 1)
+    with pytest.raises(ValueError, match="exceeding the limit"):
+        _ensure_part_size_is_valid(file_size, DEFAULT_PART_SIZE)
+
+
+def test_validate_part_count_allows_fitting_file() -> None:
+    file_size = DEFAULT_PART_SIZE * MAX_UPLOAD_PARTS
+    _ensure_part_size_is_valid(file_size, DEFAULT_PART_SIZE)


### PR DESCRIPTION
Add upload `part_size` argument so that the user can configure the chunk size to split the file they are uploading. Defaults to 10MB. Warns if part_size leads to more than 10.000 parts upload (max limit of infra).

  - Added a `part_size` argument (bytes, default DEFAULT_PART_SIZE) to both `upload_dataset_file` and `create_submission_with_upload`.
  - On resume, `part_size` is ignored since the value recorded in the state file is reused so already-uploaded parts stay valid.
  -  `MINIMUM_PART_SIZE = 5 MB`: rejects a smaller `part_size` up front with a clear `ValueError` (the storage backend rejects parts under 5 MB, except the last).
  - `MAX_UPLOAD_PARTS = 10_000`: validates that `ceil(file_size / part_size) ≤ 10,000`, raising a `ValueError` that tells the user the minimum `part_size` to use.
  - Update docs
  - Add tests


 