### PR TITLE
Avoid rate-limiting when a dataset is already downloaded

### DIFF
--- a/src/datacollective/datasets.py
+++ b/src/datacollective/datasets.py
@@ -11,10 +11,8 @@ from datacollective.api_utils import (
 from datacollective.archive_utils import _extract_archive
 from datacollective.download import (
     DOWNLOAD_SOURCE_SAVE,
+    _download_dataset,
     DOWNLOAD_SOURCE_LOAD,
-    _get_download_plan,
-    _resolve_download_dir,
-    _resolve_and_execute_download_plan,
 )
 from datacollective.logging_utils import (
     _enable_logging,
@@ -90,18 +88,18 @@ def download_dataset(
     _enable_logging(enable_logging)
     logger.info(f"Downloading dataset {dataset_id}")
 
-    _id = resolve_dataset_id(dataset_id)
-    download_plan = _get_download_plan(
-        _id,
-        download_directory,
-        download_source=DOWNLOAD_SOURCE_SAVE,
-    )
-    return _resolve_and_execute_download_plan(
-        download_plan=download_plan,
+    dataset_details = get_dataset_details(dataset_id)
+    _id = dataset_details["id"]
+
+    archive_path = _download_dataset(
+        dataset_id=_id,
+        archive_filename=dataset_details["filename"],
+        download_directory=download_directory,
         show_progress=show_progress,
         overwrite_existing=overwrite_existing,
         download_source=DOWNLOAD_SOURCE_SAVE,
     )
+    return archive_path
 
 
 def load_dataset(
@@ -147,31 +145,33 @@ def load_dataset(
         requests.HTTPError: For other non-2xx responses.
     """
     _enable_logging(enable_logging)
-    logger.info("Loading dataset `%s`", dataset_id)
+    logger.info(f"Loading dataset {dataset_id}")
 
-    _id = resolve_dataset_id(dataset_id)
+    dataset_details = get_dataset_details(dataset_id)
+    archive_filename = dataset_details["filename"]
+    _id = dataset_details["id"]
+    archive_checksum = dataset_details.get("checksum", "")
+
+    # try to fetch schema from registry
     schema = _get_dataset_schema(_id)
     if schema is None:
         raise RuntimeError(
             f"Dataset '{_id}' exists but is not supported by load_dataset yet. "
             f"You can download the raw archive with: download_dataset('{_id}'). "
-            f"If you are the data owner consider submitting a schema for your dataset via the registry: https://mozilla-data-collective.github.io/dataset-schema-registry/"
+            f"If you are the data owner consider submitting a schema for your dataset via"
+            f" the registry: https://mozilla-data-collective.github.io/dataset-schema-registry/"
         )
 
-    download_plan = _get_download_plan(
-        _id,
-        download_directory,
-        download_source=DOWNLOAD_SOURCE_LOAD,
-    )
-    archive_checksum = download_plan.checksum
-
-    archive_path = _resolve_and_execute_download_plan(
-        download_plan=download_plan,
+    archive_path = _download_dataset(
+        dataset_id=_id,
+        archive_filename=archive_filename,
+        download_directory=download_directory,
         show_progress=show_progress,
         overwrite_existing=overwrite_existing,
         download_source=DOWNLOAD_SOURCE_LOAD,
     )
-    base_dir = _resolve_download_dir(download_directory)
+
+    base_dir = archive_path.parent
     extract_dir = _extract_archive(
         archive_path=archive_path,
         dest_dir=base_dir,
@@ -180,28 +180,6 @@ def load_dataset(
 
     schema = _resolve_schema(_id, extract_dir, archive_checksum)
     return _load_dataset_from_schema(schema, extract_dir)
-
-
-def resolve_dataset_id(dataset_id: str) -> str:
-    """
-    Resolves a dataset ID or slug to its canonical MDC ID.
-
-    Args:
-        dataset_id: The dataset ID (as shown in MDC platform) or slug.
-
-    Returns:
-        The canonical dataset ID.
-
-    Raises:
-        RuntimeError: If the dataset does not exist.
-    """
-    try:
-        dataset_details = get_dataset_details(dataset_id)
-        return dataset_details.get("id", "")
-    except FileNotFoundError:
-        raise RuntimeError(
-            f"Dataset '{dataset_id}' does not exist in MDC or the ID is mistyped."
-        )
 
 
 def save_dataset_to_disk(

--- a/src/datacollective/datasets.py
+++ b/src/datacollective/datasets.py
@@ -49,7 +49,7 @@ def get_dataset_details(dataset_id: str) -> dict[str, Any]:
 
     url = f"{_get_api_url()}/datasets/{dataset_id}"
     resp = _send_api_request(method="GET", url=url)
-    return dict(resp.json())
+    return resp.json()
 
 
 def download_dataset(

--- a/src/datacollective/download.py
+++ b/src/datacollective/download.py
@@ -24,7 +24,6 @@ DOWNLOAD_SOURCE_LOAD = "load_dataset"
 
 class DownloadPlan(NonEmptyStrModel):
     download_url: str
-    filename: str
     target_filepath: Path
     tmp_filepath: Path
     size_bytes: int = Field(..., gt=0)
@@ -34,9 +33,90 @@ class DownloadPlan(NonEmptyStrModel):
     checksum_filepath: Path
 
 
+def _download_dataset(
+    dataset_id: str,
+    archive_filename: str,
+    download_directory: str | None,
+    show_progress: bool,
+    overwrite_existing: bool,
+    download_source: str | None = None,
+) -> Path:
+    """
+    Download a dataset archive from MDC to a local directory.
+
+    Flow:
+    1. Check if the dataset archive already exists in the download directory.
+        If it does and overwrite_existing is False, skip download.
+    2. Call the MDC API to get a download session URL and other necessary details.
+    3. If overwrite_existing is True, clean up any existing files.
+    4. Determine whether to resume download based on existing .checksum and .part files.
+        If not resuming, write a new .checksum file.
+    5. Execute the download plan, downloading to a temporary file.
+    6. Once download is complete, rename the temporary file to the target filename and remove the .checksum file.
+
+    Args:
+        dataset_id: The unique dataset ID.
+        archive_filename: The archive filename.
+        download_directory: The directory to download the dataset archive to.
+        show_progress: Show a progress bar when downloading the dataset.
+        overwrite_existing: If True, overwrite any existing dataset archive in the download directory.
+        download_source: Optional context appended to the User-Agent for download analytics.
+    Returns:
+        The full path to the downloaded dataset archive.
+    """
+    # Check for already fully downloaded cached version of the dataset archive
+    base_dir = _resolve_download_dir(download_directory)
+    target_filepath = base_dir / archive_filename
+    if target_filepath.exists() and not overwrite_existing:
+        logger.info(
+            f"Skipping download. Dataset archive already exists at `{str(target_filepath)}`"
+        )
+        return target_filepath
+
+    # Call MDC API to start download session
+    download_plan = _get_download_plan(
+        dataset_id=dataset_id,
+        target_filepath=target_filepath,
+        download_source=download_source,
+    )
+
+    # If overwriting, clean up any existing complete or partial download files
+    if overwrite_existing:
+        logger.info(
+            f"Overwriting existing file. Cleaning up any existing files at `{str(download_plan.target_filepath)}`"
+        )
+        _cleanup_partial_download(
+            download_plan.tmp_filepath, download_plan.checksum_filepath
+        )
+        if target_filepath.exists():
+            target_filepath.unlink()
+
+    # Determine whether to resume download based on existing .checksum and .part files
+    resume_checksum = _determine_resume_state(download_plan)
+
+    # Write checksum file before starting download (for potential resume later)
+    if download_plan.checksum and not resume_checksum:
+        download_plan.checksum_filepath.write_text(download_plan.checksum)
+
+    _execute_download_plan(
+        download_plan=download_plan,
+        resume_download_checksum=resume_checksum,
+        show_progress=show_progress,
+        download_source=download_source,
+    )
+
+    # Download complete. Rename temp file to target and remove checksum file
+    download_plan.tmp_filepath.replace(target_filepath)
+    if download_plan.checksum_filepath.exists():
+        download_plan.checksum_filepath.unlink()
+
+    logger.info(f"Saved dataset to `{target_filepath}`")
+    return target_filepath
+
+
 def _get_download_plan(
     dataset_id: str,
-    download_directory: str | None,
+    target_filepath: Path,
     download_source: str | None = None,
 ) -> DownloadPlan:
     """
@@ -44,18 +124,11 @@ def _get_download_plan(
 
     Args:
         dataset_id: The dataset ID (as shown in MDC platform).
-        download_directory: Directory where to save the downloaded dataset.
-            If None or empty, falls back to env MDC_DOWNLOAD_PATH or default.
+        target_filepath: Resolved, absolute full file path to save the downloaded dataset.
         download_source: Optional context appended to the User-Agent for download analytics.
 
     Returns:
-        a DownloadPlan containing:
-        - a download session URL created by the API
-        - the filename for the dataset archive defined by the API
-        - the final target filepath on disk where the archive will be saved
-        - a temporary path for atomic download
-        - the size of the dataset archive in bytes
-        - the checksum of the dataset
+        a DownloadPlan object
 
     Raises:
         ValueError: If dataset_id is empty.
@@ -64,44 +137,36 @@ def _get_download_plan(
         RuntimeError: If rate limit is exceeded (429) or unexpected response format.
         requests.HTTPError: For other non-2xx responses.
     """
-    if not dataset_id or not dataset_id.strip():
-        raise ValueError("`dataset_id` must be a non-empty string")
-
-    base_dir = _resolve_download_dir(download_directory)
-
-    # Create a download session to get `downloadUrl` and `filename`
+    # Create a download session to get `downloadUrl` and `sizeBytes`
     session_url = f"{_get_api_url()}/datasets/{dataset_id}/download"
     resp = _send_api_request(
         method="POST", url=session_url, source_function=download_source
     )
 
-    payload: dict[str, Any] = dict(resp.json())
+    payload: dict[str, Any] = resp.json()
     download_url = payload.get("downloadUrl")
-    filename = payload.get("filename")
     size_bytes = payload.get("sizeBytes")
     checksum = payload.get("checksum")
 
-    if not download_url or not filename or not size_bytes:
+    if not download_url or not size_bytes:
         raise RuntimeError(f"Unexpected response format: {payload}")
-
-    target_filepath = base_dir / filename
 
     # Stream download to a temporary file for atomicity
     tmp_filepath = target_filepath.with_name(target_filepath.name + ".part")
 
     checksum_filepath = _get_checksum_filepath(target_filepath)
 
+    size_bytes = int(str(size_bytes))
     download_plan = DownloadPlan(
-        download_url=download_url,
-        filename=filename,
+        download_url=str(download_url),
         target_filepath=target_filepath,
         tmp_filepath=tmp_filepath,
-        size_bytes=int(size_bytes),
+        size_bytes=size_bytes,
         checksum=checksum,
         checksum_filepath=checksum_filepath,
     )
     logger.debug(
-        f"Download plan: filename={filename}, size={int(size_bytes)} bytes, target={target_filepath}",
+        f"Download plan: full path={target_filepath}, size={size_bytes} bytes, checksum={checksum}",
     )
     return download_plan
 
@@ -166,67 +231,6 @@ def _determine_resume_state(download_plan: DownloadPlan) -> str | None:
     return None
 
 
-def _resolve_and_execute_download_plan(
-    download_plan: DownloadPlan,
-    show_progress: bool,
-    overwrite_existing: bool,
-    download_source: str | None = None,
-) -> Path:
-    """
-    Resolve the different scenarios / cases of the download plan and
-    execute the download through the API in the target directory.
-
-    Args:
-        download_plan: The DownloadPlan object with download details.
-        show_progress: Whether to show a progress bar during download.
-        overwrite_existing: Whether to overwrite existing complete archive file.
-        download_source: Optional context appended to the User-Agent for download analytics.
-    Returns:
-        Path to the downloaded dataset archive.
-    """
-
-    # Case 1: Skip download if complete dataset archive already exists
-    if download_plan.target_filepath.exists() and not overwrite_existing:
-        logger.info(
-            f"File already exists. "
-            f"Skipping download: `{str(download_plan.target_filepath)}`"
-        )
-        return Path(download_plan.target_filepath)
-
-    # If overwriting, clean up any existing complete or partial download files
-    if overwrite_existing:
-        logger.info(
-            f"Overwriting existing file. Cleaning up any existing files at `{str(download_plan.target_filepath)}`"
-        )
-        _cleanup_partial_download(
-            download_plan.tmp_filepath, download_plan.checksum_filepath
-        )
-        if download_plan.target_filepath.exists():
-            download_plan.target_filepath.unlink()
-
-    # Determine whether to resume download based on existing .checksum and .part files
-    resume_checksum = _determine_resume_state(download_plan)
-
-    # Write checksum file before starting download (for potential resume later)
-    if download_plan.checksum and not resume_checksum:
-        _write_checksum_file(download_plan.checksum_filepath, download_plan.checksum)
-
-    _execute_download_plan(
-        download_plan=download_plan,
-        resume_download_checksum=resume_checksum,
-        show_progress=show_progress,
-        download_source=download_source,
-    )
-
-    # Download complete. Rename temp file to target and remove checksum file
-    download_plan.tmp_filepath.replace(download_plan.target_filepath)
-    if download_plan.checksum_filepath.exists():
-        download_plan.checksum_filepath.unlink()
-
-    logger.info(f"Saved dataset to `{str(download_plan.target_filepath)}`")
-    return Path(download_plan.target_filepath)
-
-
 def _execute_download_plan(
     download_plan: DownloadPlan,
     resume_download_checksum: str | None,
@@ -253,7 +257,7 @@ def _execute_download_plan(
     progress_bar = None
     session_downloaded_bytes = 0
     total_downloaded_bytes = downloaded_bytes_so_far
-    logger.info(f"Downloading dataset: {download_plan.filename}")
+    logger.info(f"Downloading dataset: {download_plan.target_filepath}")
     if show_progress:
         progress_bar = ProgressBar(download_plan.size_bytes)
         progress_bar.update(downloaded_bytes_so_far)
@@ -317,11 +321,6 @@ def _resolve_download_dir(download_directory: str | None) -> Path:
 def _get_checksum_filepath(target_filepath: Path) -> Path:
     """Return the path to the .checksum file for a given target file."""
     return target_filepath.with_suffix(target_filepath.suffix + ".checksum")
-
-
-def _write_checksum_file(checksum_filepath: Path, checksum: str) -> None:
-    """Write the checksum to the .checksum file."""
-    checksum_filepath.write_text(checksum)
 
 
 def _read_checksum_file(checksum_filepath: Path) -> str | None:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -2,21 +2,7 @@ from pathlib import Path
 
 from _pytest.monkeypatch import MonkeyPatch
 
-from datacollective.datasets import resolve_dataset_id
 from datacollective.download import _resolve_download_dir
-
-
-def test_resolve_dataset_id_returns_canonical_id(monkeypatch: MonkeyPatch) -> None:
-    def fake_get_dataset_details(dataset_id: str) -> dict[str, str]:
-        assert dataset_id == "dataset-slug"
-        return {"id": "dataset-id"}
-
-    monkeypatch.setattr(
-        "datacollective.datasets.get_dataset_details",
-        fake_get_dataset_details,
-    )
-
-    assert resolve_dataset_id("dataset-slug") == "dataset-id"
 
 
 def test_resolve_download_dir_prefers_argument(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -38,7 +38,6 @@ def _make_download_plan(
     target_filepath = tmp_path / "dataset.tar.gz"
     return DownloadPlan(
         download_url="https://example.com/download",
-        filename="dataset.tar.gz",
         target_filepath=target_filepath,
         tmp_filepath=target_filepath.with_name(target_filepath.name + ".part"),
         size_bytes=1000,
@@ -163,7 +162,6 @@ def test_get_download_plan_forwards_download_source(
         def json(self) -> dict[str, Any]:
             return {
                 "downloadUrl": "https://example.com/download",
-                "filename": "dataset.tar.gz",
                 "sizeBytes": 1000,
                 "checksum": "abc123",
             }
@@ -183,13 +181,12 @@ def test_get_download_plan_forwards_download_source(
         "datacollective.download._send_api_request", fake_send_api_request
     )
 
-    plan = _get_download_plan(
+    _get_download_plan(
         "dataset-id",
-        str(tmp_path),
+        tmp_path,
         download_source="load_dataset",
     )
 
-    assert plan.filename == "dataset.tar.gz"
     assert captured["method"] == "POST"
     assert captured["source_function"] == "load_dataset"
 


### PR DESCRIPTION
## Problem

`download_dataset` and `load_dataset` always called `_get_download_plan`, which hits the rate-limited `POST /datasets/{id}/`download endpoint, in order to obtain the archive `filename` and `checksum`. This happened even when no download was necessary (e.g. the archive was already present on disk). As a result, users re-running loads/downloads on cached datasets were getting rate-limited despite no data transfer taking place.

See #102 

### Solution

Source the `filename`, `id`, and `checksum` from `GET /datasets/{id}` (`get_dataset_details`) instead of from the download-session endpoint, and only create a download session when a download will actually happen. The existence check now runs before any call to the rate-limited endpoint.

### Core changes

- New `_download_dataset` orchestrator (replaces old `_resolve_and_execute_download_plan` function) that owns the full flow: 
  1. resolve dir
  2. check for cached archive
  3. (only if needed) create download session
  4. resume/overwrite handling
  5. execute
  6. finalize. 
- `_get_download_plan` is now only called when there is no cached downloaded dataset available. Its signature takes a resolved `target_filepath` instead of a `download_directory`, and it no longer returns `filename` (dropped from `DownloadPlan`), since the filename now comes from dataset details.
- `get_dataset_details` is the single source of dataset metadata: it validates that `filename`/`id` are present
- `resolve_dataset_id` was removed.

### How the flow changed                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                    
**Before**: resolve ID (GET) → always create download session (POST, rate-limited) → decide whether to download.                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                    
**After**: get details (GET, provides id + filename + checksum) → check if archive already exists → skip entirely if cached, otherwise create the download session (POST) and download. 

### Implications for users 

- No more rate-limiting on cached datasets, meaning repeated `load_dataset`/`download_dataset` calls on already-downloaded archives no longer touch the rate-limited endpoint. 
- No public / breaking API changes. `get_dataset_details`, `download_dataset`, `load_dataset`, and `save_dataset_to_disk` keep identical signatures