### PR TITLE
Add list/search function

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,20 @@ from datacollective import get_dataset_details
 details = get_dataset_details("your-dataset-id")
 ```
 
+
+> [!TIP]
+> Don't know the dataset ID yet? Browse or search the public catalog straight from Python, no API key needed:
+>
+> ```python
+> from datacollective import list_datasets, list_dataset_filters
+>
+> filters = list_dataset_filters()      # available tasks, locales, licenses and formats
+> page = list_datasets("swahili speech", task="ASR", results_per_page=10)
+> print(page.total)                      # matches across all pages
+> for dataset in page:
+>     print(dataset.id, dataset.slug, dataset.name)
+> ```
+
 6. **Load the dataset into a pandas DataFrame _(**Alpha version:** Only certain MDC datasets are supported right now)_**:
 
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -272,6 +272,68 @@ info = get_dataset_details("your-dataset-id")
 print(info)
 ```
 
+## Browse and search the dataset catalog
+
+You can list or search all published datasets. Results are
+paginated and each entry is a `DatasetDetails`, the same model returned by
+`get_dataset_details`.
+
+```python
+from datacollective import list_datasets
+
+# Free-text search, narrowed down with filters
+page = list_datasets(
+    "swahili speech",
+    task="ASR",  # a Task enum value or string, or a list of them
+    license_abbr="CC0-1.0",  # a License enum value or string, or a list of them
+    locale=["sw", "sw-KE"],  # any of the given locales
+    sort="newest",
+    results_per_page=20,
+    page_number=1,
+)
+
+print(f"{page.total} datasets match, showing {len(page)}")
+for dataset in page:
+    size_gb = (dataset.sizeBytes or 0) / 1e9
+    print(f"{dataset.id}  {dataset.name}  ({dataset.task}, {dataset.locale}, {size_gb:.1f} GB)")
+```
+
+Other filters: `format` (e.g. `"WAV"`), `upload_date` (`"today"`, `"thisWeek"`,
+`"thisMonth"`, `"thisYear"`), `has_sample=True` for datasets with a sample file,
+`pricing` (`"free"` or `"compensated"`) and `sort_direction` (`"asc"`/`"desc"`).
+`limit` accepts 1 to 100 results per page (the platform defaults to 24).
+
+To walk through every page, increase `page` until you have collected `total` items:
+
+```python
+from datacollective import list_datasets
+
+page_number, collected = 1, []
+while True:
+    page = list_datasets(task="TTS", results_per_page=100, page_number=page_number)
+    collected.extend(page.items)
+    if not page.items or len(collected) >= page.total:
+        break
+    page_number += 1
+```
+
+### Discover the available filter values
+
+The `task`, `locale`, `license` and `format` values that the catalog can currently
+be filtered by are exposed as well. Every value except a task is drawn from the
+published catalog, so it only appears while some dataset carries it. Filtering on a
+value absent from these lists matches nothing rather than failing:
+
+```python
+from datacollective import list_dataset_filters
+
+filters = list_dataset_filters()
+print(filters.tasks)     # e.g. ['ASR', 'TTS', 'NLP', ...]
+print(filters.locales)   # e.g. ['el', 'en', 'sw', ...]
+print(filters.licenses)  # e.g. ['CC0-1.0', 'CC-BY-4.0', ...]
+print(filters.formats)   # e.g. ['MP3', 'WAV', 'TSV', ...]
+```
+
 ### Automatic Download Resume
 
 The SDK automatically handles interrupted downloads. If a download is interrupted

--- a/src/datacollective/__init__.py
+++ b/src/datacollective/__init__.py
@@ -3,6 +3,8 @@
 from datacollective.datasets import (
     download_dataset,
     get_dataset_details,
+    list_dataset_filters,
+    list_datasets,
     load_dataset,
     save_dataset_to_disk,
 )
@@ -12,6 +14,8 @@ from datacollective.errors import (
 )
 from datacollective.models import (
     DatasetDetails,
+    DatasetFilters,
+    DatasetList,
     DatasetSubmission,
     License,
     Task,
@@ -30,6 +34,8 @@ __all__ = [
     "save_dataset_to_disk",
     "load_dataset",
     "get_dataset_details",
+    "list_datasets",
+    "list_dataset_filters",
     "create_submission_draft",
     "update_submission",
     "submit_submission",
@@ -37,6 +43,8 @@ __all__ = [
     "upload_dataset_file",
     "upload_sample_file",
     "DatasetDetails",
+    "DatasetList",
+    "DatasetFilters",
     "DatasetSubmission",
     "License",
     "Task",

--- a/src/datacollective/api_utils.py
+++ b/src/datacollective/api_utils.py
@@ -118,7 +118,15 @@ def _send_api_request(
         from datacollective.errors import RateLimitError
 
         raise RateLimitError(response=resp)
-    resp.raise_for_status()
+    try:
+        resp.raise_for_status()
+    except requests.HTTPError as exc:
+        # Surface the API's message (e.g. which query parameter was
+        # rejected with 400) instead of only the generic status line.
+        detail = _extract_error_detail(resp)
+        if detail:
+            raise requests.HTTPError(f"{exc} — {detail}", response=resp) from None
+        raise
 
     return resp
 

--- a/src/datacollective/datasets.py
+++ b/src/datacollective/datasets.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, overload
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import pandas as pd
 
@@ -10,7 +11,16 @@ from datacollective.api_utils import (
     _get_api_url,
     _send_api_request,
 )
-from datacollective.models import DatasetDetails, _require_archive_filename
+from datacollective.models import (
+    DatasetDetails,
+    DatasetFilters,
+    DatasetList,
+    License,
+    Task,
+    _normalize_filter_values,
+    _require_archive_filename,
+    _validate_option,
+)
 from datacollective.archive_utils import _extract_archive
 from datacollective.download import (
     DOWNLOAD_SOURCE_SAVE,
@@ -30,6 +40,11 @@ if TYPE_CHECKING:
     from datasets import Dataset, DatasetDict
 
 RETURN_FORMATS = ("pandas", "hf")
+SORT_OPTIONS = ("relevance", "newest", "size")
+SORT_DIRECTIONS = ("asc", "desc")
+UPLOAD_DATE_OPTIONS = ("today", "thisWeek", "thisMonth", "thisYear")
+PRICING_OPTIONS = ("compensated", "free")
+MAX_PAGE_SIZE = 100
 
 logger = get_logger(__name__)
 
@@ -243,6 +258,119 @@ def load_dataset(
     if return_format == "hf":
         return _convert_to_hf(df, schema)
     return df
+
+
+def list_datasets(
+    query: str | None = None,
+    *,
+    results_per_page: int | None = None,
+    page_number: int | None = None,
+    task: Task | str | Sequence[Task | str] | None = None,
+    locale: str | Sequence[str] | None = None,
+    license_abbr: License | str | Sequence[License | str] | None = None,
+    file_format: str | Sequence[str] | None = None,
+    sort: Literal["relevance", "newest", "size"] | None = None,
+    sort_direction: Literal["asc", "desc"] | None = None,
+    upload_date: Literal["today", "thisWeek", "thisMonth", "thisYear"] | None = None,
+    has_sample: bool | None = None,
+    pricing: Literal["compensated", "free"] | None = None,
+) -> DatasetList:
+    """
+    List or search the public dataset catalog of the MDC platform.
+
+    This is a public endpoint: no API key (`MDC_API_KEY`) is required.
+    Results are paginated; use `page_number` together with the returned `total` to walk
+    through the whole catalog. The values accepted by the `task`, `locale`,
+    `license_abbr` and `file_format` filters can be discovered with `list_dataset_filters`.
+    Filtering on a value absent from those lists matches nothing rather than failing.
+
+    Args:
+        query: Free-text search string (e.g. `swahili speech`). Matches all datasets when omitted.
+        results_per_page: Results per page, between 1 and 100. The platform defaults to 24.
+        page_number: 1-based page number. Defaults to the first page.
+        task: ML task(s) to keep, either a `Task` enum value or its string value (e.g. `ASR`).
+            Pass a list to match any of several tasks.
+        locale: Language/locale code(s) to keep (e.g. `en`, `de-DE`). Pass a list to match any.
+        license_abbr: License abbreviation(s) to keep, either a `License` enum value or a string
+            (e.g. `CC0-1.0`). Pass a list to match any.
+        file_format: File format(s) to keep (e.g. `WAV`, `TSV`). Pass a list to match any.
+        sort: Result ordering: `relevance`, `newest` or `size`.
+        sort_direction: `asc` or `desc`, applied to `sort`.
+        upload_date: Only datasets published within the given window:
+            `today`, `thisWeek`, `thisMonth` or `thisYear`.
+        has_sample: When True, only datasets that provide a sample file.
+        pricing: free or compensated datasets
+
+    Returns:
+        A DatasetList with the matching `items` for the requested page and the
+        `total` number of matches across all pages.
+
+    Raises:
+        ValueError: If an argument is out of range or not one of the accepted options.
+        RuntimeError: If rate limit is exceeded (429).
+        requests.HTTPError: For other non-2xx responses (e.g. 400 for a filter value the API rejects).
+        pydantic.ValidationError: If the API response does not match the expected shape.
+    """
+    if query is not None and not query.strip():
+        raise ValueError("`query` must be a non-empty string when provided")
+    if results_per_page is not None and not 1 <= results_per_page <= MAX_PAGE_SIZE:
+        raise ValueError(
+            f"`results_per_page` must be between 1 and {MAX_PAGE_SIZE}, got {results_per_page}"
+        )
+    if page_number is not None and page_number < 1:
+        raise ValueError(
+            f"`page_number` must be a positive (1-based) integer, got {page_number}"
+        )
+    _validate_option("sort", sort, SORT_OPTIONS)
+    _validate_option("sort_direction", sort_direction, SORT_DIRECTIONS)
+    _validate_option("upload_date", upload_date, UPLOAD_DATE_OPTIONS)
+    _validate_option("pricing", pricing, PRICING_OPTIONS)
+
+    params: dict[str, Any] = {
+        "q": query.strip() if query is not None else None,
+        "limit": results_per_page,
+        "page": page_number,
+        "task": _normalize_filter_values("task", task),
+        "locale": _normalize_filter_values("locale", locale),
+        "license": _normalize_filter_values("license", license_abbr),
+        "format": _normalize_filter_values("format", file_format),
+        "sort": sort,
+        "sortDirection": sort_direction,
+        "uploadDate": upload_date,
+        # The API treats any truthy string as "has a sample"; omitting it means "no filter".
+        "sample": "true" if has_sample else None,
+        "pricing": pricing,
+    }
+    params = {key: value for key, value in params.items() if value is not None}
+
+    url = f"{_get_api_url()}/datasets"
+    resp = _send_api_request(
+        method="GET", url=url, params=params, include_auth_headers=False
+    )
+    return DatasetList.model_validate(resp.json())
+
+
+def list_dataset_filters() -> DatasetFilters:
+    """
+    Return the filter values that `list_datasets` currently accepts.
+
+    This is a public endpoint: no API key (`MDC_API_KEY`) is required.
+
+    Every value except a task is drawn from the published catalog, so it appears
+    only while some dataset carries it; the task vocabulary is fixed.
+
+    Returns:
+        A DatasetFilters model with the available `tasks`, `locales`, `licenses`
+        and `formats`.
+
+    Raises:
+        RuntimeError: If rate limit is exceeded (429).
+        requests.HTTPError: For other non-2xx responses.
+        pydantic.ValidationError: If the API response does not match the expected shape.
+    """
+    url = f"{_get_api_url()}/datasets/filters"
+    resp = _send_api_request(method="GET", url=url, include_auth_headers=False)
+    return DatasetFilters.model_validate(resp.json())
 
 
 def save_dataset_to_disk(

--- a/src/datacollective/models.py
+++ b/src/datacollective/models.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from enum import Enum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Sequence
 
 from pydantic import (
     BaseModel,
@@ -326,9 +327,44 @@ class DatasetSubmission(NonEmptyStrModel, Dataset):
         return "usd" if self.isPaid else None
 
 
+class DatasetOrganization(BaseModel):
+    """Organization that published a dataset."""
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str | None = Field(None, description="Display name of the organization.")
+    slug: str | None = Field(None, description="URL-friendly slug of the organization.")
+
+
+class DatasetPricing(BaseModel):
+    """Pricing of a dataset. All price fields are `None` for free datasets."""
+
+    model_config = ConfigDict(extra="allow")
+
+    isPaid: bool | None = Field(
+        None, description="Whether the dataset is compensated (has a price)."
+    )
+    basePriceCents: int | None = Field(
+        None, description="Base price set by the provider, in USD cents."
+    )
+    currency: str | None = Field(None, description="Currency code (`usd`).")
+    platformFeeRate: str | None = Field(
+        None,
+        description="Platform fee rate applied on top of the base price (e.g. `0.05`).",
+    )
+    platformFeeCents: int | None = Field(None, description="Platform fee in USD cents.")
+    totalPriceCents: int | None = Field(
+        None,
+        description="Total price paid by the buyer (base + platform fee), in USD cents.",
+    )
+
+
 class DatasetDetails(Dataset):
     """
     Dataset details as returned by the MDC API (read model).
+
+    Returned by `get_dataset_details` and, one per entry, by `list_datasets`:
+    the platform serves the same dataset payload from both endpoints.
 
     Tolerant of platform schema changes by design: fields the API adds are
     kept as extra attributes, fields the API removes simply read as None,
@@ -348,6 +384,23 @@ class DatasetDetails(Dataset):
     checksum: str | None = Field(
         None, description="Checksum of the current dataset file version."
     )
+    sizeBytes: int | float | None = Field(
+        None, description="Size of the dataset archive in bytes."
+    )
+    organization: DatasetOrganization | None = Field(
+        None, description="Organization that published the dataset."
+    )
+    pricing: DatasetPricing | None = Field(
+        None,
+        description="Pricing information. Prefer this over the top-level `isPaid`/`basePriceCents`, which the API has deprecated.",
+    )
+    datasetUrl: str | None = Field(
+        None, description="URL of the dataset page on the MDC platform."
+    )
+    submissionId: str | None = Field(
+        None,
+        description="Identifier of the underlying submission. Only present for datasets owned by the caller.",
+    )
 
     def __contains__(self, key: object) -> bool:
         # Mirrors the previous dict semantics: only keys the API actually
@@ -365,6 +418,58 @@ class DatasetDetails(Dataset):
             return self[key]
         except KeyError:
             return default
+
+
+class DatasetList(BaseModel):
+    """
+    One page of the public dataset catalog, as returned by `list_datasets`.
+
+    Supports `len()`, iteration and indexing over `items` for convenience.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    items: list[DatasetDetails] = Field(
+        default_factory=list, description="Datasets on this page."
+    )
+    total: int = Field(
+        ...,
+        description="Number of matching datasets across the whole result set, not just this page.",
+    )
+
+    def __len__(self) -> int:
+        return len(self.items)
+
+    def __iter__(self) -> Iterator[DatasetDetails]:  # type: ignore[override]
+        return iter(self.items)
+
+    def __getitem__(self, index: int) -> DatasetDetails:
+        return self.items[index]
+
+
+class DatasetFilters(BaseModel):
+    """
+    The values `list_datasets` can currently be narrowed by, as returned by
+    `list_dataset_filters`.
+
+    Every value except a task is drawn from the published catalog, so it appears
+    only while some dataset carries it; the task vocabulary is fixed.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    tasks: list[str] = Field(
+        default_factory=list, description="Available `task` values."
+    )
+    locales: list[str] = Field(
+        default_factory=list, description="Available `locale` values."
+    )
+    licenses: list[str] = Field(
+        default_factory=list, description="Available `license` (abbreviation) values."
+    )
+    formats: list[str] = Field(
+        default_factory=list, description="Available `format` values."
+    )
 
 
 FINAL_SUBMISSION_REQUIRED_FIELDS = (
@@ -497,3 +602,33 @@ def _require_archive_filename(details: DatasetDetails) -> str:
             f"Dataset '{details.id}' details did not include an archive filename."
         )
     return details.filename
+
+
+def _validate_option(name: str, value: str | None, allowed: tuple[str, ...]) -> None:
+    if value is not None and value not in allowed:
+        raise ValueError(
+            f"Invalid {name} '{value}'. Supported values: {', '.join(allowed)}"
+        )
+
+
+def _normalize_filter_values(
+    name: str, value: Task | License | str | Sequence[Task | License | str] | None
+) -> list[str] | None:
+    """Turn a single filter value or a sequence of them into a list of API strings."""
+    if value is None:
+        return None
+    raw_values: Sequence[Task | License | str]
+    if isinstance(value, (str, Enum)):
+        raw_values = [value]
+    else:
+        raw_values = value
+
+    normalized: list[str] = []
+    for item in raw_values:
+        item_str = item.value if isinstance(item, Enum) else str(item)
+        if not item_str.strip():
+            raise ValueError(f"`{name}` values must be non-empty strings")
+        normalized.append(item_str.strip())
+    if not normalized:
+        raise ValueError(f"`{name}` must contain at least one value when provided")
+    return normalized

--- a/tests/e2e/test_list_datasets_e2e.py
+++ b/tests/e2e/test_list_datasets_e2e.py
@@ -1,0 +1,96 @@
+import pytest
+
+from datacollective import (
+    DatasetFilters,
+    DatasetList,
+    DatasetDetails,
+    get_dataset_details,
+    list_dataset_filters,
+    list_datasets,
+)
+from tests.e2e.conftest import skip_if_rate_limited
+
+
+@pytest.fixture
+def live_public_api_env(live_api_env: None, monkeypatch) -> None:
+    """GET /datasets and GET /datasets/filters are public: run them with no API key."""
+    monkeypatch.delenv("MDC_API_KEY", raising=False)
+
+
+def test_list_dataset_filters_live_api(live_public_api_env: None) -> None:
+    """NOTE: This test calls a live MDC API endpoint (dev)."""
+    filters = None
+
+    try:
+        filters = list_dataset_filters()
+    except Exception as exc:
+        skip_if_rate_limited(exc)
+
+    assert isinstance(filters, DatasetFilters)
+    # The task vocabulary is fixed on the platform and always populated.
+    assert filters.tasks
+    assert all(isinstance(task, str) and task for task in filters.tasks)
+    assert isinstance(filters.locales, list)
+    assert isinstance(filters.licenses, list)
+    assert isinstance(filters.formats, list)
+
+
+def test_list_datasets_live_api(live_public_api_env: None) -> None:
+    """NOTE: This test calls a live MDC API endpoint (dev)."""
+    page = None
+
+    try:
+        page = list_datasets(results_per_page=5, page_number=1, sort="newest")
+    except Exception as exc:
+        skip_if_rate_limited(exc)
+
+    assert isinstance(page, DatasetList)
+    assert page.total >= len(page)
+    assert len(page) <= 5
+    for item in page:
+        assert isinstance(item, DatasetDetails)
+        assert item.id.strip()
+        assert item.slug and item.slug.strip()
+        assert item.name and item.name.strip()
+
+
+def test_list_datasets_filter_roundtrip_live_api(live_public_api_env: None) -> None:
+    """Filter by the first advertised task and check every result carries it.
+
+    NOTE: This test calls a live MDC API endpoint (dev).
+    """
+    page = None
+
+    try:
+        filters = list_dataset_filters()
+        assert filters.tasks
+        task = filters.tasks[0]
+        page = list_datasets(task=task, results_per_page=10)
+    except Exception as exc:
+        skip_if_rate_limited(exc)
+
+    assert page is not None
+    assert all(item.task == task for item in page)
+
+
+def test_list_datasets_matches_details_live_api(
+    live_public_api_env: None, dev_dataset_id: str
+) -> None:
+    """A catalog entry must resolve to the same dataset via `get_dataset_details`.
+
+    NOTE: This test calls a live MDC API endpoint (dev).
+    """
+    page = None
+
+    try:
+        details = get_dataset_details(dev_dataset_id)
+        assert details.name
+        page = list_datasets(details.name, results_per_page=50)
+    except Exception as exc:
+        skip_if_rate_limited(exc)
+
+    assert page is not None
+    matches = [item for item in page if item.id == dev_dataset_id]
+    assert matches, f"Dataset {dev_dataset_id} not found when searching its own name"
+    assert matches[0].slug == details.slug
+    assert matches[0].filename == details.filename

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -278,3 +278,48 @@ def test_submission_shared_fields_still_validated() -> None:
     with pytest.raises(ValidationError):
         DatasetSubmission(locale="   ")
     assert DatasetSubmission(locale=" en-US ").locale == "en-US"
+
+
+def test_dataset_details_parses_catalog_fields_and_keeps_extra_fields() -> None:
+    details = DatasetDetails.model_validate(
+        {
+            "id": "cmt95wvb80027qb6e2vezm3d9",
+            "task": "NEW_TASK",
+            "sizeBytes": 1024,
+            "organization": {"name": "Mozilla", "slug": "mozilla"},
+            "pricing": {
+                "isPaid": True,
+                "basePriceCents": 10000,
+                "totalPriceCents": 10500,
+            },
+            "datasetUrl": "https://mozilladatacollective.com/datasets/cmt95wvb80027qb6e2vezm3d9",
+            "newField": 1,
+        }
+    )
+
+    assert details.sizeBytes == 1024
+    assert details.organization is not None
+    assert details.organization.name == "Mozilla"
+    assert details.pricing is not None
+    assert details.pricing.totalPriceCents == 10500
+    assert details.submissionId is None
+    # Unknown task values and new fields must not break validation.
+    assert details.task == "NEW_TASK"
+    assert details.model_extra == {"newField": 1}
+
+
+def test_dataset_filters_tolerates_new_keys() -> None:
+    from datacollective.models import DatasetFilters
+
+    filters = DatasetFilters.model_validate(
+        {
+            "tasks": ["ASR"],
+            "locales": ["el"],
+            "licenses": ["CC0-1.0"],
+            "formats": ["MP3"],
+            "organizations": ["mozilla"],
+        }
+    )
+
+    assert filters.tasks == ["ASR"]
+    assert filters.model_extra == {"organizations": ["mozilla"]}


### PR DESCRIPTION
Two new endpoints get two new SDK functions -> `GET /datasets` and `GET /datasets/filters`!

This lets users discover datasets from Python, without knowing a dataset ID/slug first.
Neither endpoint needs an API key.

- `list_datasets` lets users both list the catalog, or search with specific free text queries, with the ability to narrow down the search using filters. Results are returned paginated and user can explicitly set # of items per page, and which page. Supports `len()`, iteration and indexing!!
- `list_dataset_filters` lets users get the exact available values for the filters provided by the endpoint
- Results are pydantic models (`DatasetList` & `DatasetFilter`) so that users can have typed access to the fields
- `DatasetDetails` got a few new typed fields that were missing 
- `DatasetOrganization` and `DatasetPricing` to mirror the API spec


Example:
                                                                                                                                                                                                            
```python                                                                                                                                                                                                 
from datacollective import list_datasets, Task                                                                                                                                                            
                                                                                                                                                                                                          
page = list_datasets(                                                                                                                                                                                     
    "swahili speech",                                                                                                                                                                                     
    task=[Task.ASR, Task.TTS],                                                                                                                                                                            
    sort="newest",                                                                                                                                                                                        
    results_per_page=20,                                                                                                                                                                                  
)                                                                                                                                                                                                         
                                                                                                                                                                                                          
print(f"{page.total} matches")                                                                                                                                                                            
for dataset in page:                                                                                                                                                                                      
    print(dataset.id, dataset.name, dataset.locale, dataset.sizeBytes)
  ```